### PR TITLE
ui(queue): remove the hidden hard-attention priority band

### DIFF
--- a/ui/packages/web/queue-order-fixture.html
+++ b/ui/packages/web/queue-order-fixture.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Queue order fixture (no priority band)</title>
+<div id="root"></div>
+<script type="module" src="/src/queue-order-fixture.tsx"></script>

--- a/ui/packages/web/src/components/TodosView.tsx
+++ b/ui/packages/web/src/components/TodosView.tsx
@@ -118,8 +118,8 @@ function resumeNativeAnchoring(): void {
 export function TodosView() {
   const board = useBoard()
   // The queue is EXACTLY the server-derived Needs-you session threads (t.needsYou) — legacy .fray rows
-  // never card anymore. Concrete unresolved asks/crashes lead passive rest/done handoffs, with
-  // interaction recency providing deterministic order inside each priority band.
+  // never card anymore. One strictly time-ordered list (no priority band): every card orders by
+  // last-active alone, FIFO (oldest-first) by default or LIFO per the queueOrder preference.
   const items = orderQueue(asThreads(board?.threads ?? []).filter(queued), useSnapshot(prefs).queueOrder)
   const itemKey = items.map((i) => i.id).join(",")
 

--- a/ui/packages/web/src/groups.test.ts
+++ b/ui/packages/web/src/groups.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
 import type { ThreadView } from "@fray-ui/shared"
-import { needsAction, queued, queuePriority, orderQueue, partitionActive, sectionOf, sectionThreads, isHeld, sessionIndicatorKind, titleIsProvisional, displayTitle, lastActiveLabelAt, SPINNING_UP_TITLE, UNTITLED_THREAD_TITLE } from "./groups.ts"
+import { needsAction, queued, orderQueue, partitionActive, sectionOf, sectionThreads, isHeld, sessionIndicatorKind, titleIsProvisional, displayTitle, lastActiveLabelAt, SPINNING_UP_TITLE, UNTITLED_THREAD_TITLE } from "./groups.ts"
 
 // Minimal ThreadView fixture — the same shape board-delta.test.ts uses, defaulting to a live/active
 // thread; each case overrides only the fields under test.
@@ -145,30 +145,24 @@ test("queued: pre-restart snapshot (no kind/needsYou) degrades to an empty queue
   assert.equal(queued(thread({})), false)
 })
 
-test("queuePriority: only unresolved asks, prompts, permissions, and crashes outrank passive handoffs", () => {
-  assert.equal(queuePriority(thread({ actionableInteraction: true })), 0)
-  assert.equal(queuePriority(thread({ pendingAsk: { questions: [] } })), 0)
-  assert.equal(queuePriority(thread({ nativeInputRequired: { kind: "permission", title: "Permission required" } })), 0)
-  assert.equal(queuePriority(thread({ pendingQuestion: true })), 0)
-  assert.equal(queuePriority(thread({ runtime: "perm-prompt" })), 0)
-  assert.equal(queuePriority(thread({ crashed: true })), 0)
-  assert.equal(queuePriority(thread({ status: "needs-human", humanBlocked: true })), 0)
-  assert.equal(queuePriority(thread({ pendingInteraction: true, actionableInteraction: false })), 1, "answered provider delivery remains readable, not actionable")
-  assert.equal(queuePriority(thread({ lastFence: { kind: "done", body: "shipped", hints: [] } })), 1)
-  assert.equal(queuePriority(thread()), 1)
-})
-
-test("orderQueue: hard attention leads; FIFO (oldest-waiting first) and id order each band", () => {
-  const queue = orderQueue([
-    thread({ id: "done-new", lastUserAt: "2026-07-13T12:00:00.000Z", lastFence: { kind: "done", body: "shipped", hints: [] } }),
-    thread({ id: "hard-b", lastUserAt: "2026-07-11T12:00:00.000Z", pendingQuestion: true }),
-    thread({ id: "rest-newer", lastUserAt: "2026-07-14T12:00:00.000Z" }),
-    thread({ id: "hard-a", lastUserAt: "2026-07-11T12:00:00.000Z", actionableInteraction: true }),
-    thread({ id: "hard-older", lastUserAt: "2026-07-10T12:00:00.000Z", crashed: true }),
-  ])
-  // Hard band FIFO (oldest first): hard-older (07-10) leads; hard-a/hard-b share 07-11 so id breaks the
-  // tie (a<b). Rest band FIFO: done-new (07-13) before rest-newer (07-14). Bands never interleave.
-  assert.deepEqual(queue.map((item) => item.id), ["hard-older", "hard-a", "hard-b", "done-new", "rest-newer"])
+test("orderQueue: NO priority band — one strict time order across attention + passive alike", () => {
+  // The hidden hard-attention band is gone (maintainer 2026-07-21: "too confusing"). Order is
+  // last-active alone; kind (crash/question vs done/rest) never lifts a card into a separate tier.
+  // The timestamps deliberately INTERLEAVE attention and passive rows so BOTH directions differ from
+  // the old banded order — proving band removal, not just re-proving FIFO:
+  //   crash-newest 07-14 (hard) · done-newer 07-13 (passive) · question-older 07-11 (hard) · rest-oldest 07-10 (passive)
+  // Old banded FIFO would be [question-older, crash-newest, rest-oldest, done-newer]; old banded LIFO
+  // [crash-newest, question-older, done-newer, rest-oldest]. Both differ from the strict orders below.
+  const rows = () => [
+    thread({ id: "crash-newest", lastUserAt: "2026-07-14T12:00:00.000Z", crashed: true }),
+    thread({ id: "done-newer", lastUserAt: "2026-07-13T12:00:00.000Z", lastFence: { kind: "done", body: "shipped", hints: [] } }),
+    thread({ id: "question-older", lastUserAt: "2026-07-11T12:00:00.000Z", pendingQuestion: true }),
+    thread({ id: "rest-oldest", lastUserAt: "2026-07-10T12:00:00.000Z" }),
+  ]
+  // FIFO oldest-first: the fresh CRASH sinks to the BOTTOM under an older done card — the accepted tradeoff.
+  assert.deepEqual(orderQueue(rows()).map((item) => item.id), ["rest-oldest", "question-older", "done-newer", "crash-newest"])
+  // LIFO newest-first: a newer DONE card outranks an older question — impossible under the old band.
+  assert.deepEqual(orderQueue(rows(), "lifo").map((item) => item.id), ["crash-newest", "done-newer", "question-older", "rest-oldest"])
 })
 
 test("orderQueue: AT-REST rows key on REST TIME (lastAssistantAt), not lastActivityAt; direction flips it", () => {

--- a/ui/packages/web/src/groups.ts
+++ b/ui/packages/web/src/groups.ts
@@ -203,43 +203,23 @@ export function orderByInteraction(threads: readonly ThreadView[]): ThreadView[]
   })
 }
 
-// Queue cards have two deliberately small priority bands. A concrete unresolved request or failure
-// comes before an ordinary bare-rest/done handoff, even when that passive handoff was touched more
-// recently. Within a band, the queue orders FIFO (see orderQueue) so the human cycles through all
-// waiting work instead of re-triaging whatever rested most recently.
-// `pendingInteraction` is intentionally absent: a response still awaiting provider acknowledgement
-// remains readable, but only `actionableInteraction` means the human still owes a decision.
-export type QueuePriority = 0 | 1
-
-export function queuePriority(t: ThreadView): QueuePriority {
-  const hardAttention = Boolean(
-    t.actionableInteraction ||
-      t.pendingAsk ||
-      t.nativeInputRequired ||
-      t.pendingQuestion ||
-      t.runtime === "perm-prompt" ||
-      t.crashed ||
-      t.humanBlocked ||
-      t.status === "needs-human",
-  )
-  return hardAttention ? 0 : 1
-}
-
-// Within each priority band, order by DIRECTION (a per-browser view preference — see lib/prefs.ts):
+// The queue is a SINGLE strictly time-ordered list — no priority band. Every waiting card orders by
+// DIRECTION (a per-browser view preference — see lib/prefs.ts) alone, so the visible "oldest first"
+// rule is literally true across every card, attention and passive alike (maintainer 2026-07-21:
+// removed the hidden hard-attention band — "too confusing"; a fresh crash/permission-prompt no longer
+// floats above an older done card):
 //   • FIFO (default): the thread gone LONGEST without activity surfaces first (oldest lastActiveAt =
 //     ascending), so answering it sends it to the BACK of the line and the next-oldest rises — the
 //     human cycles through every waiting item instead of endlessly re-triaging whatever rested most
 //     recently (maintainer 2026-07-15: "first in first out is a better system… you are not constantly
 //     cycling through all of the tasks").
 //   • LIFO: the most-recently-active first (descending) — the older last-in-first-out feel.
-// The hard-attention band always leads regardless. lastActiveAt keys off when an AT-REST thread came
-// to rest (matching its "Last active" label) and off the stable user-interaction time for a running
-// row, so agent tool churn never reorders a card. id-tiebroken for a stable order among equal-age rows.
+// lastActiveAt keys off when an AT-REST thread came to rest (matching its "Last active" label) and off
+// the stable user-interaction time for a running row, so agent tool churn never reorders a card.
+// id-tiebroken for a stable order among equal-age rows.
 export function orderQueue(threads: readonly ThreadView[], direction: QueueDirection = "fifo"): ThreadView[] {
   const dir = direction === "lifo" ? -1 : 1
   return [...threads].sort((a, b) => {
-    const priority = queuePriority(a) - queuePriority(b)
-    if (priority !== 0) return priority
     const age = (lastActiveAt(a) - lastActiveAt(b)) * dir
     return age !== 0 ? age : a.id.localeCompare(b.id)
   })

--- a/ui/packages/web/src/queue-order-fixture.tsx
+++ b/ui/packages/web/src/queue-order-fixture.tsx
@@ -1,0 +1,110 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { createRoot } from "react-dom/client"
+import type { BoardSnapshot, ThreadView as ThreadViewModel, TranscriptMessage } from "@fray-ui/shared"
+import { TodosView } from "./components/TodosView.tsx"
+import { TooltipProvider } from "./components/Tooltip.tsx"
+import { store } from "./store.ts"
+import "./styles.css"
+
+// Browser QA for the NO-priority-band queue (maintainer 2026-07-21: the hidden hard-attention band was
+// "too confusing" — removed). The queue is now ONE strict last-active order. This fixture proves the
+// behavioural consequence visually: a FRESH crash (most urgent) sinks BELOW an OLDER done handoff, because
+// order is age alone. Three queued cards, oldest→newest = done → question → crash. FIFO (default) must
+// render them top-to-bottom in that exact age order, urgency notwithstanding.
+const ago = (ms: number) => new Date(Date.now() - ms).toISOString()
+const MIN = 60_000
+const DAY = 24 * 60 * MIN
+
+type Seed = { id: string; title: string; at: number; extra: Partial<ThreadViewModel> }
+const SEEDS: Seed[] = [
+  { id: "oldest-done", title: "① Oldest · done handoff · 5d ago", at: 5 * DAY, extra: { runtime: "turn-idle", lastFence: { kind: "done", body: "Shipped the fix.", hints: [] } } },
+  { id: "middle-question", title: "② Middle · question · 3d ago", at: 3 * DAY, extra: { runtime: "turn-idle", pendingQuestion: true } },
+  { id: "newest-crash", title: "③ Newest · CRASH · 40m ago", at: 40 * MIN, extra: { runtime: "exited", crashed: true } },
+]
+
+function makeThread({ id, title, at, extra }: Seed): ThreadViewModel {
+  return {
+    id,
+    title,
+    status: "active",
+    statusText: "Waiting on your call",
+    mechanism: null,
+    humanBlocked: false,
+    needsYou: true,
+    ready: false,
+    dependsOn: [],
+    externalDeps: [],
+    agents: [],
+    errors: [],
+    warnings: [],
+    runtime: "turn-idle",
+    unread: false,
+    archived: false,
+    hasPlan: false,
+    pendingQuestion: false,
+    kind: "session",
+    foreign: false,
+    backend: "claude",
+    permissionMode: "default",
+    subAgents: [],
+    bgShells: [],
+    lastUserAt: ago(at),
+    lastActivityAt: ago(at),
+    spawnedAt: ago(at),
+    ...extra,
+  } as unknown as ThreadViewModel
+}
+
+const threads = SEEDS.map(makeThread)
+store.board = { projectDir: "/fixture/fray", threads } as BoardSnapshot
+
+// Each card pulls its own short transcript; everything else is a benign empty RPC (no real server here).
+// Queries carry their input in the `?input=` query param (GET) — see api/rpc.ts — not a POST body.
+function slugFromReq(url: URL, init?: RequestInit): string | null {
+  try {
+    const q = url.searchParams.get("input")
+    if (q) return JSON.parse(q)?.slug ?? null
+    const body = typeof init?.body === "string" ? JSON.parse(init.body) : null
+    return body?.slug ?? body?.params?.slug ?? null
+  } catch {
+    return null
+  }
+}
+const originalFetch = window.fetch
+window.fetch = async (input, init) => {
+  const url = new URL(typeof input === "string" ? input : (input as Request).url ?? input.toString(), location.origin)
+  if (url.pathname === "/rpc/threadTranscript" || url.pathname === "/rpc/threadTranscriptEarlier") {
+    const slug = slugFromReq(url, init) ?? SEEDS[0].id
+    const seed = SEEDS.find((s) => s.id === slug) ?? SEEDS[0]
+    const messages: TranscriptMessage[] = [
+      { sourceId: `${seed.id}-u1`, role: "user", text: `Handle: ${seed.title}.`, tools: [], parts: [] },
+      { sourceId: `${seed.id}-a1`, role: "assistant", text: seed.title, tools: [], parts: [{ kind: "text", text: seed.title }] },
+    ]
+    return new Response(JSON.stringify({ result: { messages, transcriptKey: `${seed.id}-key`, hasEarlier: false, historyLoaded: true } }), { headers: { "content-type": "application/json" } })
+  }
+  if (url.pathname.startsWith("/rpc/")) {
+    return new Response(JSON.stringify({ result: {} }), { headers: { "content-type": "application/json" } })
+  }
+  return originalFetch(input, init)
+}
+
+// Mirror App's <main> so the queue lays out exactly as production.
+function Fixture() {
+  return (
+    <div className="relative min-h-screen bg-bg text-fg text-sm">
+      <div className="flex min-h-screen justify-center">
+        <main className="w-[720px] max-w-[62vw] min-w-0 flex flex-col py-5 min-h-screen max-[800px]:w-full max-[800px]:max-w-none">
+          <TodosView />
+        </main>
+      </div>
+    </div>
+  )
+}
+
+createRoot(document.getElementById("root")!).render(
+  <QueryClientProvider client={new QueryClient()}>
+    <TooltipProvider>
+      <Fixture />
+    </TooltipProvider>
+  </QueryClientProvider>,
+)


### PR DESCRIPTION
## What

The Needs-you queue sorted by a **hidden two-band priority** — band 0 (hard-attention: questions, permission-prompts, crashes, `needs-human`) always led band 1 (passive done / bare-rest handoffs) — *before* the FIFO/LIFO last-active tiebreak. So "Oldest first" only held **within** a band, and a recently-rested question sat above older done cards, reading as though the ordering preference were broken.

Per maintainer decision (2026-07-21, "too confusing"), this removes the band. `orderQueue` now orders **purely by `lastActiveAt`** — one undivided list, FIFO (oldest-first, default) or LIFO. The visible "Oldest first" rule is now literally true across every card.

**Accepted tradeoff:** a fresh crash / permission-prompt now sinks below older done cards (it's the oldest-first cost the maintainer chose deliberately). Attention states still surface as row **indicators** — only the *ordering* no longer floats them.

## Changes

- **`groups.ts`** — drop the `queuePriority` term from `orderQueue`; delete the now-dead `QueuePriority` type + `queuePriority()`; rewrite the doc comment.
- **`groups.test.ts`** — replace the banded test with one that proves the band is gone in **both** directions (interleaved attention/passive timestamps, so the old banded FIFO *and* LIFO orders both differ from the new strict orders).
- **`TodosView.tsx`** — comment refresh.
- **`queue-order-fixture.{html,tsx}`** — new browser-QA fixture driving the **real** `TodosView` with three controlled-age queued threads (done 5d / question 3d / crash 40m).

`orderActive` still routes the sidebar's rested band through `orderQueue`, so queue cards and sidebar rested rows stay in one shared order — the scroll-marker monotonicity invariant is preserved (both surfaces change together, no divergence).

## Verification

- `tsc -b` (server bundle) + web `tsc --noEmit` → clean.
- All **385** web tests pass; the rewritten `orderQueue` test fails under the old banded comparator (real regression guard, confirmed by an independent adversarial review).
- **Runtime gate:** drove the real `TodosView` via the new fixture (vite dev + headless puppeteer). Rendered DOM order is strict oldest-first — `oldest-done → mid-question → newest-crash` — with the fresh crash last, desktop + narrow, no console errors.

https://claude.ai/code/session_01L4bTLh9Rmrd7ANRA9TL2HK
