### PR TITLE
Fix multiline queued answers

### DIFF
--- a/ui/packages/server/src/tmux.test.ts
+++ b/ui/packages/server/src/tmux.test.ts
@@ -20,6 +20,7 @@ import {
   findExpectedAdoptionPane,
   captureExpectedAdoptionPane,
   crossSocketLiveOwner,
+  sendTextToCompatibleLegacyWorker,
   sendTextWithKey,
   sendTextWithKeyToExpectedAdoptionPane,
   sendTextToExpectedAdoptionPane,
@@ -29,6 +30,7 @@ import {
   socketName,
   spawn,
   spawnWithRunner,
+  pasteText,
   TmuxSpawnError,
 } from "./tmux.ts"
 
@@ -40,6 +42,105 @@ const tmuxAvailable = (() => {
     return false
   }
 })()
+
+const bracketedPasteConsumer = [
+  "process.stdin.setRawMode(true)",
+  "process.stdin.resume()",
+  "let input = Buffer.alloc(0)",
+  "process.stdout.write('\\u001b[?2004hREADY\\n')",
+  "process.stdin.on('data', chunk => {",
+  "  input = Buffer.concat([input, chunk])",
+  "  if (input.includes(Buffer.from('\\u001b[201~'))) process.stdout.write('\\nINPUT:' + input.toString('hex') + '\\n')",
+  "})",
+].join(";\n")
+
+async function waitForBracketedPaste(target: string, activeSocket = socketName()): Promise<void> {
+  const readyBy = Date.now() + 2_000
+  while (Date.now() < readyBy) {
+    const flag = execFileSync("tmux", ["-L", activeSocket, "display-message", "-p", "-t", target, "#{bracket_paste_flag}"], { encoding: "utf8" }).trim()
+    if (flag === "1") return
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+  assert.fail("the test consumer did not enable bracketed-paste mode")
+}
+
+async function captureBracketedInput(target: string, message: string, activeSocket = socketName()): Promise<string> {
+  const expected = Buffer.from(`\u001b[200~${message.replaceAll("\n", "\r")}\u001b[201~`).toString("hex")
+  const deliveredBy = Date.now() + 2_000
+  let pane = ""
+  while (Date.now() < deliveredBy) {
+    pane = execFileSync("tmux", ["-L", activeSocket, "capture-pane", "-p", "-t", target], { encoding: "utf8" })
+    if (pane.includes(`INPUT:${expected}`)) return pane
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+  assert.fail(`the bracketed payload was not delivered; pane: ${pane}`)
+}
+
+test("pasteText keeps a multiline follow-up inside one bracketed-paste payload", { skip: !tmuxAvailable }, async () => {
+  const originalSocket = socketName()
+  const slug = `bracketed-paste-${process.pid}`
+  setSocket(`fray-bracketed-paste-test-${process.pid}`)
+  try {
+    spawn(slug, [process.execPath, "-e", bracketedPasteConsumer], process.cwd())
+
+    const target = tmuxSessionName(slug)
+    await waitForBracketedPaste(target)
+
+    const message = "Answers:\n2. A. Leave it to your normal release flow"
+    pasteText(slug, message)
+    await captureBracketedInput(target, message)
+  } finally {
+    killSession(slug)
+    setSocket(originalSocket)
+  }
+})
+
+test("exact adopted-pane sends keep multiline follow-ups inside bracketed-paste framing", { skip: !tmuxAvailable }, async () => {
+  const originalSocket = socketName()
+  const slug = `bracketed-adoption-${process.pid}`
+  const token = randomUUID()
+  setSocket(`fray-bracketed-adoption-test-${process.pid}`)
+  try {
+    const exact = spawn(slug, [process.execPath, "-e", bracketedPasteConsumer], process.cwd(), undefined, {
+      adoptionAttemptToken: token,
+    })
+    await waitForBracketedPaste(exact.paneId)
+
+    const message = "Answers:\n2. A. Leave it to your normal release flow"
+    assert.equal(sendTextToExpectedAdoptionPane({
+      attempt_token: token,
+      pane_id: exact.paneId,
+      pane_pid: exact.panePid,
+      session_created: exact.sessionCreated,
+    }, message, true), true)
+    await captureBracketedInput(exact.paneId, message)
+  } finally {
+    killSession(slug)
+    setSocket(originalSocket)
+  }
+})
+
+test("compatible legacy sends keep multiline follow-ups inside bracketed-paste framing", { skip: !tmuxAvailable }, async () => {
+  const originalSocket = socketName()
+  const slug = `bracketed-legacy-${process.pid}`
+  setSocket(`fray-bracketed-legacy-test-${process.pid}`)
+  try {
+    const exact = spawn(slug, [process.execPath, "-e", bracketedPasteConsumer], process.cwd())
+    await waitForBracketedPaste(exact.paneId)
+
+    const message = "Answers:\n2. A. Leave it to your normal release flow"
+    assert.equal(sendTextToCompatibleLegacyWorker({
+      socket: socketName(),
+      paneId: exact.paneId,
+      panePid: exact.panePid,
+      sessionCreated: exact.sessionCreated,
+    }, message), true)
+    await captureBracketedInput(exact.paneId, message)
+  } finally {
+    killSession(slug)
+    setSocket(originalSocket)
+  }
+})
 
 test("deriveSocket: per-project socket name from the stable project id", () => {
   // UUIDs retain all 128 bits; the historical first-eight mapping could collide.

--- a/ui/packages/server/src/tmux.ts
+++ b/ui/packages/server/src/tmux.ts
@@ -216,7 +216,7 @@ export function sendTextToCompatibleLegacyWorker(worker: CompatibleLegacyWorker,
     const out = execFileSync("tmux", ["-L", worker.socket,
       "load-buffer", "-b", buffer, "-", ";",
       "if-shell", "-t", worker.paneId, "-F", compatibleLegacyCondition(worker),
-      `paste-buffer -b ${buffer} -t ${worker.paneId} ; send-keys -t ${worker.paneId} Enter ; display-message -p ${EXACT_ACTION_OK}`,
+      `paste-buffer -p -b ${buffer} -t ${worker.paneId} ; send-keys -t ${worker.paneId} Enter ; display-message -p ${EXACT_ACTION_OK}`,
       `display-message -p ${EXACT_ACTION_MISS}`, ";", "delete-buffer", "-b", buffer],
     { input: text, encoding: "utf8", stdio: ["pipe", "pipe", "ignore"] })
     return out.trimEnd().endsWith(EXACT_ACTION_OK)
@@ -535,7 +535,7 @@ function sendTextWithKeyToPane(
   const buffer = `${bufferPrefix}-${randomUUID()}`
   const complete = `send-keys -t ${paneId} ${key} ; display-message -p ${EXACT_ACTION_OK}`
   const afterSettle = `if-shell -t ${paneId} -F '${condition}' '${complete}' 'display-message -p ${EXACT_ACTION_MISS}'`
-  const authorized = `paste-buffer -b ${buffer} -t ${paneId} ; run-shell '${INPUT_SETTLE_COMMAND}' ; ${afterSettle}`
+  const authorized = `paste-buffer -p -b ${buffer} -t ${paneId} ; run-shell '${INPUT_SETTLE_COMMAND}' ; ${afterSettle}`
   try {
     const out = execFileSync("tmux", [
       "-L", socketName,
@@ -616,7 +616,7 @@ export function sendTextToExpectedAdoptionPane(
       "load-buffer", "-b", buffer, "-",
       ";",
       "if-shell", "-t", expected.pane_id, "-F", condition,
-      `paste-buffer -b ${buffer} -t ${expected.pane_id}${submit ? ` ; send-keys -t ${expected.pane_id} Enter` : ""} ; display-message -p ${EXACT_ACTION_OK}`,
+      `paste-buffer -p -b ${buffer} -t ${expected.pane_id}${submit ? ` ; send-keys -t ${expected.pane_id} Enter` : ""} ; display-message -p ${EXACT_ACTION_OK}`,
       `display-message -p ${EXACT_ACTION_MISS}`,
       ";",
       "delete-buffer", "-b", buffer,
@@ -1022,10 +1022,12 @@ export function sendKey(slug: string, key: "Enter" | "Tab" | "Up" | "Down" | "Es
 }
 
 // Multiline-safe injection: stage the text in a tmux paste-buffer (load-buffer from stdin,
-// so newlines/quotes survive untouched), paste it, then Enter. -d deletes the buffer after.
+// so newlines/quotes survive untouched), request bracketed-paste framing, then send a distinct Enter.
+// Without -p, an active Claude turn can treat the first embedded newline as submit and queue only the
+// first line (for example, `Answers:`) while silently losing the rest of the logical follow-up.
 export function pasteText(slug: string, text: string): void {
   const name = tmuxSessionName(slug)
   execFileSync("tmux", ["-L", socket, "load-buffer", "-"], { input: text })
-  tmux("paste-buffer", "-t", name, "-d")
+  tmux("paste-buffer", "-p", "-t", name, "-d")
   tmux("send-keys", "-t", name, "Enter")
 }


### PR DESCRIPTION
## Summary

- preserve multiline Claude follow-ups as one bracketed-paste payload across standalone, adopted-pane, and compatible-legacy transports
- prevent a second question answer from truncating to only `Answers:` while an earlier turn is active
- add real tmux PTY regressions for all three transport paths

## Root cause

Fray used `tmux paste-buffer` without `-p`. When Claude had enabled bracketed-paste mode, an embedded newline in a multiline answer could act as submit during an active turn. Claude queued only the first line while Fray retained the full optimistic browser message, so the UI could never reconcile it.

## Verification

- `pnpm exec tsx --tsconfig packages/web/tsconfig.json --test packages/server/src/tmux.test.ts` — 14/14 pass after rebase
- `pnpm test` — 1475 pass, 9 skip, 1 unrelated baseline failure: launcher fixture expects marker `v3` while current launcher emits `v4`
- real Chrome/Chromium QA through `agent-browser`: submitted the remaining question answer during an active Claude turn; the provider received the full multiline payload and emitted `SECOND ANSWER RECEIVED` with the selected answer
- desktop and 390px narrow screenshots inspected; no page errors and no visible wrapping, truncation, or alignment defects

## Current main note

After rebasing onto the latest `origin/main`, `pnpm typecheck` reports pre-existing errors in `GithubPickerModal.tsx` and `githubDispatch.ts`. This PR changes only `tmux.ts` and `tmux.test.ts`; the targeted server tests remain green.

The PR's `version-check` also inherits the current main-branch failure in `portable-monitors.test.mjs`, which still reads the deleted `ui/WORKER_PROMPT.codex.md`. The latest exact-main run failed the same way: https://github.com/colinhacks/fray/actions/runs/29855076718.
