### PR TITLE
Compact snooze and watcher handoffs

### DIFF
--- a/ui/packages/web/src/components/ChatView.tsx
+++ b/ui/packages/web/src/components/ChatView.tsx
@@ -32,7 +32,7 @@ import { threadLifecycleAvailability } from "../lib/threadLifecycle.ts"
 import { Tooltip } from "./Tooltip.tsx"
 import { ToolDisclosureHeader } from "./ToolDisclosureHeader.ts"
 import { hasRunningToolIndicator, isRunningOperation, liveBackgroundOperationState } from "../lib/operationIndicators.ts"
-import { formatCountdownSeconds, formatElapsedMinutes, formatFixedDuration, formatToolDuration } from "../lib/durationLabels.ts"
+import { formatElapsedMinutes, formatFixedDuration, formatToolDuration } from "../lib/durationLabels.ts"
 import { TRANSCRIPT_META_LABEL_CLASS } from "../lib/transcriptMetaLabels.ts"
 import { InteractionStack } from "./InteractionCards.tsx"
 import { LastActive } from "./LastActive.tsx"
@@ -2384,11 +2384,6 @@ export function FenceCard({ fenceKind, body, hints, wrap }: { fenceKind: FenceKi
                   label onto the value's optical midline so "ci"/"pr" and the ref read on one line. */}
               <span className="petite-caps relative -top-px text-[9.5px] text-muted/60">{h.kind}</span>
               <span className={h.kind === "timer" ? "min-w-0 break-words" : "font-mono-keep"}>{timerLabel ?? (h.kind === "timer" ? "Schedule unavailable" : h.value)}</span>
-              {/* A live countdown to a timer wait — fray-ui owns this durable wake (it resumes the session when
-                  this fires), so the card shows the human exactly when that happens. */}
-              {/* The timestamp remains the primary information on a narrow queue card; hide the
-                  auxiliary live countdown there so neither value truncates or wraps awkwardly. */}
-              {h.kind === "timer" && <span className="hidden sm:inline"><TimerCountdown iso={h.value} /></span>}
             </span>
             )
           })}
@@ -2697,25 +2692,6 @@ export function PendingAskCard({ ask, onTerminal }: { ask: PendingAsk; onTermina
       </button>
     </div>
   )
-}
-
-// A live countdown to a timer wait's ISO instant, rendered inside the awaiting card's `timer` chip.
-// fray-ui's wakers scheduler OWNS this wake — it resumes the session when `now >= iso` — so the human
-// sees exactly how long until that happens. Ticks once a second (cheap; unmounts with the card). Past
-// due → "firing…" (the scheduler resumes within a tick; the fence then clears and this card vanishes).
-function TimerCountdown({ iso }: { iso: string }) {
-  const target = useMemo(() => Date.parse(iso), [iso])
-  const [now, setNow] = useState(() => Date.now())
-  useEffect(() => {
-    if (!Number.isFinite(target)) return
-    const id = setInterval(() => setNow(Date.now()), 1000)
-    return () => clearInterval(id)
-  }, [target])
-  if (!Number.isFinite(target)) return null
-  const remain = Math.floor((target - now) / 1000)
-  if (remain <= 0) return <span className="ml-0.5 text-[10px] text-muted/60 italic">firing…</span>
-  const label = formatCountdownSeconds(remain)
-  return <span className="ml-0.5 tabular-nums text-[10px] text-muted/60">in {label}</span>
 }
 
 // Human-friendly elapsed since an ISO timestamp: "just now", "12m", "1h 3m". Empty when unparseable.

--- a/ui/packages/web/src/components/ChatView.tsx
+++ b/ui/packages/web/src/components/ChatView.tsx
@@ -3,7 +3,7 @@ import { useSnapshot } from "valtio"
 import * as RadixTabs from "@radix-ui/react-tabs"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useVirtualizer } from "@tanstack/react-virtual"
-import { AlertTriangle, ArrowDown, ArrowLeft, ArrowUpRight, Check, ChevronRight, Clock, FileText, HelpCircle, KeyRound, ListChecks, Loader2, ShieldCheck, Sparkles, X } from "lucide-react"
+import { AlertTriangle, ArrowDown, ArrowLeft, ArrowUpRight, Check, ChevronRight, FileText, HelpCircle, KeyRound, ListChecks, Loader2, ShieldCheck, Sparkles, X } from "lucide-react"
 import type { AwaitingHint, NativeInputRequired as NativeInputRequiredData, PendingAsk, ThreadView as ThreadViewData, TranscriptEdit, TranscriptMessage, TranscriptToolCall } from "@fray-ui/shared"
 import { isValidAwaitingTimer } from "@fray-ui/shared"
 import { store, threadBySlug, pushDrawer, pushSubAgentDrawer, showToast } from "../store.ts"
@@ -20,7 +20,8 @@ import { useLiveAnswering, type LiveAnswering } from "../lib/answering.ts"
 import { useLocalFileCodeLinks } from "../lib/localFileCode.ts"
 import { shouldSubmitComposerEnter } from "../lib/composerKeyboard.ts"
 import { messagePresentationText } from "../lib/messagePresentation.ts"
-import { formatSnoozedUntil, snoozePresetInstant, formatSnoozeWake } from "../lib/snooze.ts"
+import { snoozePresetInstant, formatSnoozeWake } from "../lib/snooze.ts"
+import { awaitingHintSentence, awaitingPresentationLine } from "../lib/awaitingPresentation.ts"
 import { prefs } from "../lib/prefs.ts"
 import { canAdoptThread } from "../lib/adoption.ts"
 import { THREAD_TITLE_MAX_LENGTH, aiRenameAvailability, manualThreadTitleSeed, threadTitleToCommit } from "../lib/threadTitle.ts"
@@ -2321,10 +2322,13 @@ export function QuestionBlockCard({
 
 // A SIGNAL fence rendered as a card in place of the raw ```done / ```awaiting block (the fence
 // language IS the state; the body is the message). `done` → a compact presentation-only success card;
-// its thread's Archive lives in the stable lifecycle footer. `awaiting` → a quiet parked-wait card:
-// body prose plus parsed hint chips (human/timer, with legacy pr/ci/session support).
+// its thread's Archive lives in the stable lifecycle footer. `awaiting` → one compact handoff row:
+// body prose plus one plain-English action summary (with legacy pr/ci/session support).
 export function FenceCard({ fenceKind, body, hints, wrap }: { fenceKind: FenceKind; body: string; hints: AwaitingHint[]; wrap?: boolean }) {
   const html = useMemo(() => (body ? mdToHtml(body) : ""), [body])
+  const awaitingHint = awaitingHintSentence(hints)
+  const awaitingLine = awaitingPresentationLine(body, awaitingHint)
+  const awaitingHtml = useMemo(() => mdInlineToHtml(awaitingLine), [awaitingLine])
   // The owning thread's slug — set by the thread view AND the queue card — so the confirm button
   // resolves its thread and renders on both surfaces (null in a sub-agent's own transcript → no button).
   const slug = useContext(ThreadSlugContext)
@@ -2369,26 +2373,11 @@ export function FenceCard({ fenceKind, body, hints, wrap }: { fenceKind: FenceKi
     )
   }
   return (
-    <div className="rounded-lg border border-border-strong bg-panel-2 px-4 py-3">
-      <div className="mb-1.5 flex items-center gap-1.5 text-[10px] uppercase tracking-wide text-muted/70">
-        <Clock size={12} className="shrink-0" /> Awaiting
-      </div>
-      {html && <div className={`md-body${wrap ? ` ${QUEUE_WRAP}` : ""}`} dangerouslySetInnerHTML={{ __html: html }} />}
-      {hints.length > 0 && (
-        <div className="mt-2 flex flex-wrap gap-1.5">
-          {hints.map((h, i) => {
-            const timerLabel = h.kind === "timer" ? formatSnoozedUntil(h.value) : null
-            return (
-            <span key={i} className="flex min-w-0 items-center gap-1 rounded-md border border-border bg-panel px-2 py-0.5 text-[11px] text-fg/80">
-              {/* petite-caps sit on the baseline → ~1px low under items-center (see styles.css); lift the
-                  label onto the value's optical midline so "ci"/"pr" and the ref read on one line. */}
-              <span className="petite-caps relative -top-px text-[9.5px] text-muted/60">{h.kind}</span>
-              <span className={h.kind === "timer" ? "min-w-0 break-words" : "font-mono-keep"}>{timerLabel ?? (h.kind === "timer" ? "Schedule unavailable" : h.value)}</span>
-            </span>
-            )
-          })}
-        </div>
-      )}
+    <div className="flex min-w-0 items-stretch rounded-lg border border-border-strong bg-panel-2">
+      <div
+        className={`md-inline min-w-0 flex-1 content-center px-3 py-2 text-[12px] leading-5 text-fg/85${wrap ? ` ${QUEUE_WRAP}` : ""}`}
+        dangerouslySetInnerHTML={{ __html: awaitingHtml }}
+      />
       {canAct && fenceThread && <AwaitingParkButton thread={fenceThread} hints={hints} />}
     </div>
   )
@@ -2432,7 +2421,7 @@ function AwaitingParkButton({ thread, hints }: { thread: ThreadViewData; hints: 
       .finally(() => setBusy(false))
   }
   return (
-    <div className="mt-3">
+    <div className="flex shrink-0 items-center justify-end border-l border-border px-2 py-1.5">
       <button
         type="button"
         onClick={apply}
@@ -2440,9 +2429,9 @@ function AwaitingParkButton({ thread, hints }: { thread: ThreadViewData; hints: 
         aria-label={action.label}
         title={action.label}
         onMouseDown={(e) => e.preventDefault()}
-        className="flex items-center gap-1.5 rounded-md bg-fg px-2.5 py-1 text-[12px] font-medium text-bg outline-none transition-opacity hover:opacity-90 focus-visible:ring-1 focus-visible:ring-fg/60 disabled:opacity-45"
+        className="flex items-center gap-1.5 whitespace-nowrap rounded-md border border-border bg-panel px-2 py-1 text-[11px] font-medium text-fg/85 outline-none transition-colors hover:border-border-strong hover:bg-panel-2 hover:text-fg focus-visible:ring-1 focus-visible:ring-fg/60 disabled:opacity-45"
       >
-        {busy ? <Loader2 size={12} className="animate-spin" /> : <Clock size={12} />}
+        {busy && <Loader2 size={11} className="animate-spin" />}
         {action.label}
       </button>
     </div>

--- a/ui/packages/web/src/done-card-button-fixture.tsx
+++ b/ui/packages/web/src/done-card-button-fixture.tsx
@@ -9,7 +9,7 @@ import "./styles.css"
 // sets in production:
 //   • the done card's white "Mark as done" button (completeThread; ?mode=executing → needsConfirmation
 //     → the End-session dialog path)
-//   • the awaiting card's white confirm-park button, one per parkable kind (timer → "Confirm snooze"
+//   • the awaiting card's compact confirm-park button, one per parkable kind (timer → "Confirm snooze"
 //     to the exact instant; github-review → "Confirm watcher"; human → "Confirm snooze"). Each applies
 //     a user snooze via setThreadSnooze.
 // RPC is mocked like completion-lifecycle-fixture so nothing real is hit.
@@ -62,10 +62,10 @@ const timerIso = new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString()
 
 const cards: { slug: string; label: string; fence: "done" | "awaiting"; body: string; hints: AwaitingHint[] }[] = [
   { slug: "card-done", label: "done", fence: "done", body: "Shipped the change.", hints: [] },
-  { slug: "card-timer", label: "awaiting · timer", fence: "awaiting", body: "Parked until the checkpoint.", hints: [{ kind: "timer", value: timerIso }] },
-  { slug: "card-review", label: "awaiting · github-review", fence: "awaiting", body: "Waiting on PR review.", hints: [{ kind: "github-review", value: "owner/repo#42" }] },
-  { slug: "card-human", label: "awaiting · human", fence: "awaiting", body: "Waiting for Alice to sign off.", hints: [{ kind: "human", value: "Alice to approve the API shape" }] },
-  { slug: "card-legacy", label: "awaiting · legacy ci (no button)", fence: "awaiting", body: "Legacy machine wait — no parkable hint.", hints: [{ kind: "ci", value: "owner/repo#7" }] },
+  { slug: "card-timer", label: "timer snooze", fence: "awaiting", body: "Park until the checkpoint.", hints: [{ kind: "timer", value: timerIso }] },
+  { slug: "card-review", label: "GitHub review watcher", fence: "awaiting", body: "The implementation is ready for review.", hints: [{ kind: "github-review", value: "owner/repo#42" }] },
+  { slug: "card-human", label: "human approval", fence: "awaiting", body: "The API shape needs approval.", hints: [{ kind: "human", value: "Alice to approve the API shape" }] },
+  { slug: "card-legacy", label: "legacy CI (no button)", fence: "awaiting", body: "The legacy build is still running.", hints: [{ kind: "ci", value: "owner/repo#7" }] },
 ]
 
 // The QUEUE path: the queue card renders the fence through <Message dense> inside a ThreadSlugContext,
@@ -73,7 +73,7 @@ const cards: { slug: string; label: string; fence: "done" | "awaiting"; body: st
 // shows in the queue too. Each renders a real assistant message whose text IS the fence block.
 const queueCards: { slug: string; label: string; text: string }[] = [
   { slug: "queue-done", label: "done", text: "Shipped it.\n\n```done\nAll green.\n```" },
-  { slug: "queue-timer", label: "awaiting · timer", text: "```awaiting\nParked.\ntimer: " + timerIso + "\n```" },
+  { slug: "queue-timer", label: "timer snooze", text: "```awaiting\nPark until the checkpoint.\ntimer: " + timerIso + "\n```" },
 ]
 
 // A queue thread with a LIVE sub-agent dispatch — proves that, now the queue card provides

--- a/ui/packages/web/src/lib/awaitingPresentation.test.ts
+++ b/ui/packages/web/src/lib/awaitingPresentation.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { awaitingHintSentence, awaitingPresentationLine } from "./awaitingPresentation.ts"
+
+const now = Date.parse("2026-07-21T18:00:00.000Z")
+
+test("awaiting hints become one compact plain-English action", () => {
+  assert.match(
+    awaitingHintSentence([{ kind: "timer", value: "2026-07-21T21:00:00.000Z" }], now) ?? "",
+    /^Snooze until /,
+  )
+  assert.equal(
+    awaitingHintSentence([{ kind: "github-review", value: "owner/repo#42" }], now),
+    "Watch owner/repo#42 for new human review activity",
+  )
+  assert.equal(
+    awaitingHintSentence([{ kind: "human", value: "Alice to approve the API shape" }], now),
+    "Wait for Alice to approve the API shape",
+  )
+})
+
+test("actionable hints win and elapsed timers remain stable instead of becoming a live status", () => {
+  assert.equal(
+    awaitingHintSentence([
+      { kind: "timer", value: "not-a-time" },
+      { kind: "github-review", value: "owner/repo#42" },
+    ], now),
+    "Watch owner/repo#42 for new human review activity",
+  )
+  assert.match(
+    awaitingHintSentence([{ kind: "timer", value: "2026-07-21T17:00:00.000Z" }], now) ?? "",
+    /^Scheduled for /,
+  )
+  assert.equal(awaitingHintSentence([{ kind: "timer", value: "not-a-time" }], now), "Snooze schedule unavailable")
+})
+
+test("legacy hints degrade to readable text and an empty hint set stays empty", () => {
+  assert.equal(awaitingHintSentence([{ kind: "pr", value: "owner/repo#7" }], now), "Wait for PR owner/repo#7")
+  assert.equal(awaitingHintSentence([{ kind: "ci", value: "build 9" }], now), "Wait for CI build 9")
+  assert.equal(awaitingHintSentence([{ kind: "session", value: "sub-123" }], now), "Wait for session sub-123")
+  assert.equal(awaitingHintSentence([], now), null)
+})
+
+test("body and action join as clean prose without period-dash punctuation", () => {
+  assert.equal(
+    awaitingPresentationLine("Park until the checkpoint.", "Snooze until today at 2:00 PM"),
+    "Park until the checkpoint. Snooze until today at 2:00 PM",
+  )
+  assert.equal(
+    awaitingPresentationLine("Park until the checkpoint", "Snooze until today at 2:00 PM"),
+    "Park until the checkpoint — Snooze until today at 2:00 PM",
+  )
+  assert.equal(awaitingPresentationLine("", null), "Waiting for an external update.")
+})

--- a/ui/packages/web/src/lib/awaitingPresentation.ts
+++ b/ui/packages/web/src/lib/awaitingPresentation.ts
@@ -1,0 +1,36 @@
+import { isValidAwaitingTimer, type AwaitingHint } from "@fray-ui/shared"
+import { formatSnoozeWake } from "./snooze.ts"
+
+function lowerCalendarLead(value: string): string {
+  return value.replace(/^(Today|Tomorrow)/, (day) => day.toLowerCase())
+}
+
+export function awaitingHintSentence(hints: readonly AwaitingHint[], nowMs = Date.now()): string | null {
+  const timer = hints.find((hint) => hint.kind === "timer" && isValidAwaitingTimer(hint.value))
+  if (timer && Date.parse(timer.value) > nowMs) {
+    return `Snooze until ${lowerCalendarLead(formatSnoozeWake(timer.value, nowMs))}`
+  }
+
+  const review = hints.find((hint) => hint.kind === "github-review")
+  if (review) return `Watch ${review.value} for new human review activity`
+
+  const human = hints.find((hint) => hint.kind === "human")
+  if (human) return `Wait for ${human.value}`
+
+  if (timer) return `Scheduled for ${lowerCalendarLead(formatSnoozeWake(timer.value, nowMs))}`
+  if (hints.some((hint) => hint.kind === "timer")) return "Snooze schedule unavailable"
+
+  const legacy = hints.find((hint) => hint.kind === "pr" || hint.kind === "ci" || hint.kind === "session")
+  if (!legacy) return null
+  if (legacy.kind === "pr") return `Wait for PR ${legacy.value}`
+  if (legacy.kind === "ci") return `Wait for CI ${legacy.value}`
+  return `Wait for session ${legacy.value}`
+}
+
+export function awaitingPresentationLine(body: string, hint: string | null): string {
+  const prose = body.trim()
+  if (!prose) return hint ?? "Waiting for an external update."
+  if (!hint) return prose
+  const separator = /[.!?…][*_~`"')\]]*$/.test(prose) ? " " : " — "
+  return `${prose}${separator}${hint}`
+}

--- a/ui/packages/web/src/lib/fenceBlocks.ts
+++ b/ui/packages/web/src/lib/fenceBlocks.ts
@@ -5,7 +5,7 @@
 // body, then a closing ``` line. Pure string logic, no DOM — unit-testable.
 //
 // The signal fence LANGUAGE is the state: `done` = a presentation-only success card (thread lifecycle
-// actions live in a stable footer), `awaiting` = a parked human/timer card with hint chips. Distinct
+// actions live in a stable footer), `awaiting` = a compact parked human/timer handoff. Distinct
 // from ```question blocks (their own machinery in questionBlocks.ts) — those never match here.
 
 import type { AwaitingHint } from "@fray-ui/shared"


### PR DESCRIPTION
## Summary

- replace stacked awaiting cards with compact horizontal handoff rows
- remove the Awaiting heading, technical hint chips, live countdown, and stale firing status
- express timer, review-watcher, human, and legacy hints as quiet plain-English text
- place a small confirmation action in a right-aligned footer cell

## Verification

- pnpm --filter @fray-ui/web build
- 24 focused awaiting-presentation, fence, snooze, and duration-label tests
- Chromium QA at 1280px and 390px covering default, hover, loading, and confirmed states
- clean browser console and page-error logs; owned browser and server processes cleaned up
- independent fresh-context review completed; its punctuation finding was fixed and reverified

The repository-wide typecheck and test commands still expose unrelated failures already present on origin/main: GitHub-dispatch type errors, one server timing assertion, and the portable monitor test looking for an absent prompt path.