### PR TITLE
Fix queued-message reconciliation and Codex delivery

### DIFF
--- a/monitors/portable-monitors.test.mjs
+++ b/monitors/portable-monitors.test.mjs
@@ -37,8 +37,9 @@ test("Codex and Claude provider guidance prefer declared tooling and make no Lun
   assert.doesNotMatch(codex, /exactly one `gpt-5\.6-luna` \+ `medium` monitor child/)
   assert.match(claude, /use native `Monitor`/)
 
-  const codexPrompt = readFileSync(join(root, "ui/WORKER_PROMPT.codex.md"), "utf8")
-  const claudePrompt = readFileSync(join(root, "ui/WORKER_PROMPT.claude.md"), "utf8")
+  const promptDir = join(root, "ui/packages/server/src")
+  const codexPrompt = readFileSync(join(promptDir, "WORKER_PROMPT.codex.golden.txt"), "utf8")
+  const claudePrompt = readFileSync(join(promptDir, "WORKER_PROMPT.claude.golden.txt"), "utf8")
   for (const prompt of [codexPrompt, claudePrompt]) {
     assert.match(prompt, /project-local `AGENTS\.md`/)
     assert.match(prompt, /terminal event\/exit semantics/)

--- a/ui/packages/server/src/permission-controller.test.ts
+++ b/ui/packages/server/src/permission-controller.test.ts
@@ -44,6 +44,7 @@ function harness(storageOverride?: Storage) {
   }
   let pane = ""
   let escaped = ""
+  let cursorY: number | undefined
   let live = true
   let clock = 1_000
   let onTailerTick = () => {}
@@ -54,6 +55,7 @@ function harness(storageOverride?: Storage) {
     isLive: () => live,
     capturePane: () => pane,
     capturePaneEscaped: () => escaped,
+    capturePaneEscapedWithCursor: () => cursorY === undefined ? null : { text: escaped, cursorY },
     sendLiteral: (_slug, text) => sent.push(`literal:${text}`),
     sendKey: (slug, key) => {
       keyQueueSnapshots.push(storage.getSession(slug)?.codex_input_queue)
@@ -88,9 +90,10 @@ function harness(storageOverride?: Storage) {
     controller,
     sent,
     reattached,
-    setPane(plain: string, withEscapes = plain) {
+    setPane(plain: string, withEscapes = plain, nextCursorY?: number) {
       pane = plain
       escaped = withEscapes
+      cursorY = nextCursorY
     },
     setTelemetry(next: SessionTelemetry | undefined) {
       telemetry = next
@@ -153,6 +156,64 @@ test("composer inspection matches the exact wrapped nonempty Nub pane and the di
     inspectCodexComposer("\u001b[1m›\u001b[0m Compare alpha -\n  beta before proceeding."),
     { kind: "typed", text: "Compare alpha - beta before proceeding.", queueHint: false },
     "a standalone punctuation hyphen preserves the real following space",
+  )
+  const multiParagraphDraft =
+    "\u001b[0;1m›\u001b[0m Do not keep legacy code around.\n\n  Implement this all fully.\n\n  gpt-5.6-sol xhigh · ~/project · Context 71% used"
+  assert.deepEqual(inspectCodexComposer(multiParagraphDraft, 2), {
+    kind: "typed",
+    text: "Do not keep legacy code around. Implement this all fully.",
+    queueHint: false,
+  })
+  assert.equal(
+    codexComposerMatches(multiParagraphDraft, "Do not keep legacy code around.\n\nImplement this all fully.", 2),
+    true,
+    "interior paragraph gaps remain part of the draft while the native footer is excluded",
+  )
+  assert.equal(
+    codexComposerMatches(multiParagraphDraft, "Do not keep legacy code around.\n\nImplement this all fully."),
+    false,
+    "a legacy capture without cursor provenance fails closed at the first paragraph gap",
+  )
+  const footerLikeDraft =
+    "\u001b[0;1m›\u001b[0m Explain this phrase.\n\n  tab to queue message is user-authored.\n\n  gpt-5.6-sol xhigh\n\n  gpt-5.6-sol xhigh · ~/project · Context 71% used"
+  assert.equal(
+    codexComposerMatches(
+      footerLikeDraft,
+      "Explain this phrase.\n\ntab to queue message is user-authored.\n\ngpt-5.6-sol xhigh",
+      4,
+    ),
+    true,
+    "footer-like user paragraphs through the cursor remain part of the draft",
+  )
+  const modelLikeFinalParagraph = "\u001b[0;1m›\u001b[0m SAFE\n\n  gpt-5.6-sol xhigh"
+  assert.deepEqual(inspectCodexComposer(modelLikeFinalParagraph, 2), {
+    kind: "typed",
+    text: "SAFE gpt-5.6-sol xhigh",
+    queueHint: false,
+  })
+  assert.equal(
+    codexComposerMatches(modelLikeFinalParagraph, "SAFE", 2),
+    false,
+    "a final model-looking user paragraph cannot be discarded and auto-submitted",
+  )
+  const cursorBoundedFooter =
+    "\u001b[0;1m›\u001b[0m Keep the exact draft.\n\n  \u001b[38;2;246;226;183mgpt-5.6-sol xhigh\u001b[2m\u001b[39m · ~/project\u001b[0m\n  \u001b[2mtab to queue message\u001b[0m"
+  assert.deepEqual(inspectCodexComposer(cursorBoundedFooter, 0), {
+    kind: "typed",
+    text: "Keep the exact draft.",
+    queueHint: true,
+  })
+  assert.equal(
+    codexComposerMatches(cursorBoundedFooter, "Keep the exact draft.", 0),
+    true,
+    "rows below the composer cursor are excluded without inferring from their content",
+  )
+  const ambiguousWrappedFooter =
+    "\u001b[0;1m›\u001b[0m SAFE\n\n  gpt-5.6-sol xhigh · ~/project\n  \u001b[2mtab to queue message\u001b[0m"
+  assert.equal(
+    codexComposerMatches(ambiguousWrappedFooter, "SAFE", 2),
+    false,
+    "a following native hint cannot prove that a preceding plain model-shaped paragraph is footer chrome",
   )
 })
 
@@ -643,7 +704,7 @@ test("durable live Codex follow-up separates typing from idle Enter and clears o
   assert.equal(JSON.parse(h.storage.getSession("idle-input")?.codex_input_queue ?? "[]")[0].state, "pending")
 
   h.sent.length = 0
-  h.setPane("", "\u001b[1m›\u001b[0m Reply exactly IDLE_OK.\n\n  gpt-5.6-sol")
+  h.setPane("", "\u001b[1m›\u001b[0m Reply exactly IDLE_OK.\n\n  gpt-5.6-sol xhigh · ~/project · Context 71% used")
   h.controller.tick()
   assert.deepEqual(h.sent, ["key:Enter"])
   assert.equal(JSON.parse(h.storage.getSession("idle-input")?.codex_input_queue ?? "[]")[0].state, "submitted")
@@ -660,6 +721,41 @@ test("durable live Codex follow-up separates typing from idle Enter and clears o
   })
   h.controller.tick()
   assert.equal(h.storage.getSession("idle-input")?.codex_input_queue, null)
+})
+
+test("an identical two-paragraph Codex draft is submitted instead of blocking its queued follow-up", () => {
+  const h = harness()
+  const slug = "multi-paragraph-input"
+  const message = "Do not keep legacy code around.\n\nImplement this all fully."
+  h.storage.upsertSession(row(slug))
+  h.storage.setBackend(slug, "codex")
+  h.setTelemetry({ turn: "idle", permPrompt: false, subAgents: [], bgShells: [], pendingQuestion: false })
+  h.setPane(
+    "",
+    "\u001b[0;1m›\u001b[0m Do not keep legacy code around.\n\n  Implement this all fully.\n\n  gpt-5.6-sol xhigh · ~/project · Context 71% used",
+    2,
+  )
+
+  h.controller.queueFollowUp(slug, message)
+
+  assert.deepEqual(h.sent, ["key:Enter"])
+  assert.equal(h.storage.getSession(slug)?.control_error, null)
+  assert.equal(JSON.parse(h.storage.getSession(slug)?.codex_input_queue ?? "[]")[0].state, "submitted")
+})
+
+test("a cursor-bounded footer-like final paragraph cannot auto-submit only its queued prefix", () => {
+  const h = harness()
+  const slug = "footer-like-user-text"
+  h.storage.upsertSession(row(slug))
+  h.storage.setBackend(slug, "codex")
+  h.setTelemetry({ turn: "idle", permPrompt: false, subAgents: [], bgShells: [], pendingQuestion: false })
+  h.setPane("", "\u001b[0;1m›\u001b[0m SAFE\n\n  gpt-5.6-sol xhigh · ~/project · Context 71% used", 2)
+
+  h.controller.queueFollowUp(slug, "SAFE")
+
+  assert.deepEqual(h.sent, [])
+  assert.match(h.storage.getSession(slug)?.control_error ?? "", /existing Codex terminal draft/)
+  assert.equal(JSON.parse(h.storage.getSession(slug)?.codex_input_queue ?? "[]")[0].state, "pending")
 })
 
 test("a scheduler delivery id makes durable Codex wake enqueue idempotent", () => {
@@ -738,7 +834,7 @@ test("identical consecutive follow-ups each require their own post-submission ro
 
   h.setNow(1_000)
   h.controller.queueFollowUp("duplicate-input", "SAME")
-  h.setPane("", "\u001b[1m›\u001b[0m SAME\n\n  gpt-5.6-sol")
+  h.setPane("", "\u001b[1m›\u001b[0m SAME\n\n  gpt-5.6-sol xhigh · ~/project · Context 71% used")
   h.setNow(1_050)
   h.controller.queueFollowUp("duplicate-input", "SAME")
   assert.deepEqual(h.sent, ["literal:SAME", "key:Enter"])
@@ -760,7 +856,7 @@ test("identical consecutive follow-ups each require their own post-submission ro
   h.setPane("", emptyComposer)
   h.setNow(1_300)
   h.controller.tick()
-  h.setPane("", "\u001b[1m›\u001b[0m SAME\n\n  gpt-5.6-sol")
+  h.setPane("", "\u001b[1m›\u001b[0m SAME\n\n  gpt-5.6-sol xhigh · ~/project · Context 71% used")
   h.setNow(1_400)
   h.controller.tick()
   queue = JSON.parse(h.storage.getSession("duplicate-input")?.codex_input_queue ?? "[]")

--- a/ui/packages/server/src/permission-controller.test.ts
+++ b/ui/packages/server/src/permission-controller.test.ts
@@ -44,8 +44,8 @@ function harness(storageOverride?: Storage) {
   }
   let pane = ""
   let escaped = ""
-  let cursorY: number | undefined
   let live = true
+  let atomicSendSucceeds = true
   let clock = 1_000
   let onTailerTick = () => {}
   const sent: string[] = []
@@ -55,8 +55,12 @@ function harness(storageOverride?: Storage) {
     isLive: () => live,
     capturePane: () => pane,
     capturePaneEscaped: () => escaped,
-    capturePaneEscapedWithCursor: () => cursorY === undefined ? null : { text: escaped, cursorY },
     sendLiteral: (_slug, text) => sent.push(`literal:${text}`),
+    sendTextWithKey: (slug, text, key) => {
+      keyQueueSnapshots.push(storage.getSession(slug)?.codex_input_queue)
+      sent.push(`atomic:${key}:${text}`)
+      return atomicSendSucceeds
+    },
     sendKey: (slug, key) => {
       keyQueueSnapshots.push(storage.getSession(slug)?.codex_input_queue)
       sent.push(`key:${key}`)
@@ -90,16 +94,18 @@ function harness(storageOverride?: Storage) {
     controller,
     sent,
     reattached,
-    setPane(plain: string, withEscapes = plain, nextCursorY?: number) {
+    setPane(plain: string, withEscapes = plain) {
       pane = plain
       escaped = withEscapes
-      cursorY = nextCursorY
     },
     setTelemetry(next: SessionTelemetry | undefined) {
       telemetry = next
     },
     setLive(next: boolean) {
       live = next
+    },
+    setAtomicSendSucceeds(next: boolean) {
+      atomicSendSucceeds = next
     },
     setNow(next: number) {
       clock = next
@@ -158,63 +164,39 @@ test("composer inspection matches the exact wrapped nonempty Nub pane and the di
     "a standalone punctuation hyphen preserves the real following space",
   )
   const multiParagraphDraft =
-    "\u001b[0;1m›\u001b[0m Do not keep legacy code around.\n\n  Implement this all fully.\n\n  gpt-5.6-sol xhigh · ~/project · Context 71% used"
-  assert.deepEqual(inspectCodexComposer(multiParagraphDraft, 2), {
-    kind: "typed",
-    text: "Do not keep legacy code around. Implement this all fully.",
-    queueHint: false,
-  })
-  assert.equal(
-    codexComposerMatches(multiParagraphDraft, "Do not keep legacy code around.\n\nImplement this all fully.", 2),
-    true,
-    "interior paragraph gaps remain part of the draft while the native footer is excluded",
-  )
+    "\u001b[0;1m›\u001b[0m Do not keep legacy code around.\n\n  Implement this all fully.\n\n  gpt-5.6-sol xhigh · ~/project · gpt-5.6-sol · xhigh · Context 71% used · weekly 98% left"
+  assert.deepEqual(inspectCodexComposer(multiParagraphDraft), { kind: "unavailable" })
   assert.equal(
     codexComposerMatches(multiParagraphDraft, "Do not keep legacy code around.\n\nImplement this all fully."),
     false,
-    "a legacy capture without cursor provenance fails closed at the first paragraph gap",
+    "an already-typed multi-paragraph draft is never auto-submitted from ambiguous plain rows",
   )
   const footerLikeDraft =
-    "\u001b[0;1m›\u001b[0m Explain this phrase.\n\n  tab to queue message is user-authored.\n\n  gpt-5.6-sol xhigh\n\n  gpt-5.6-sol xhigh · ~/project · Context 71% used"
+    "\u001b[0;1m›\u001b[0m Explain this phrase.\n\n  tab to queue message is user-authored.\n\n  gpt-5.6-sol xhigh\n\n  gpt-5.6-sol xhigh · ~/project · gpt-5.6-sol · xhigh · Context 71% used · weekly 98% left"
   assert.equal(
-    codexComposerMatches(
-      footerLikeDraft,
-      "Explain this phrase.\n\ntab to queue message is user-authored.\n\ngpt-5.6-sol xhigh",
-      4,
-    ),
-    true,
-    "footer-like user paragraphs through the cursor remain part of the draft",
+    codexComposerMatches(footerLikeDraft, "Explain this phrase."),
+    false,
+    "footer-like user paragraphs cannot be discarded and prefix-submitted",
   )
   const modelLikeFinalParagraph = "\u001b[0;1m›\u001b[0m SAFE\n\n  gpt-5.6-sol xhigh"
-  assert.deepEqual(inspectCodexComposer(modelLikeFinalParagraph, 2), {
-    kind: "typed",
-    text: "SAFE gpt-5.6-sol xhigh",
-    queueHint: false,
-  })
-  assert.equal(
-    codexComposerMatches(modelLikeFinalParagraph, "SAFE", 2),
-    false,
-    "a final model-looking user paragraph cannot be discarded and auto-submitted",
-  )
-  const cursorBoundedFooter =
+  assert.deepEqual(inspectCodexComposer(modelLikeFinalParagraph), { kind: "unavailable" })
+  assert.equal(codexComposerMatches(modelLikeFinalParagraph, "SAFE"), false)
+  const styledFooter =
     "\u001b[0;1m›\u001b[0m Keep the exact draft.\n\n  \u001b[38;2;246;226;183mgpt-5.6-sol xhigh\u001b[2m\u001b[39m · ~/project\u001b[0m\n  \u001b[2mtab to queue message\u001b[0m"
-  assert.deepEqual(inspectCodexComposer(cursorBoundedFooter, 0), {
+  assert.deepEqual(inspectCodexComposer(styledFooter), {
     kind: "typed",
     text: "Keep the exact draft.",
     queueHint: true,
   })
   assert.equal(
-    codexComposerMatches(cursorBoundedFooter, "Keep the exact draft.", 0),
+    codexComposerMatches(styledFooter, "Keep the exact draft."),
     true,
-    "rows below the composer cursor are excluded without inferring from their content",
+    "a one-paragraph legacy draft remains recoverable only with independently styled footer rows",
   )
-  const ambiguousWrappedFooter =
-    "\u001b[0;1m›\u001b[0m SAFE\n\n  gpt-5.6-sol xhigh · ~/project\n  \u001b[2mtab to queue message\u001b[0m"
-  assert.equal(
-    codexComposerMatches(ambiguousWrappedFooter, "SAFE", 2),
-    false,
-    "a following native hint cannot prove that a preceding plain model-shaped paragraph is footer chrome",
-  )
+  const fullStatusUserTail =
+    "\u001b[0;1m›\u001b[0m SAFE\n\n  gpt-5.6-sol xhigh · ~/project · gpt-5.6-sol · xhigh · Context 71% used · weekly 98% left"
+  assert.deepEqual(inspectCodexComposer(fullStatusUserTail), { kind: "unavailable" })
+  assert.equal(codexComposerMatches(fullStatusUserTail, "SAFE"), false)
 })
 
 test("Claude composer inspection distinguishes the idle prompt from an unsent draft or modal", () => {
@@ -233,7 +215,7 @@ test("Claude permission footer reports the active new-pane mode without reading 
   assert.equal(detectClaudePermissionMode(`${"auto mode on\n".repeat(15)}❯\u00a0\n────\n  no status footer`), undefined)
 })
 
-test("a queued follow-up whose Codex visual wrap splits a hyphenated token still submits exactly once", () => {
+test("an idle queued follow-up is pasted and submitted by one terminal operation", () => {
   const h = harness()
   h.storage.upsertSession(row("wrapped-hyphen"))
   h.storage.setBackend("wrapped-hyphen", "codex")
@@ -242,14 +224,8 @@ test("a queued follow-up whose Codex visual wrap splits a hyphenated token still
   const message = "Call the connector for fray-native-audit/restart-test and wait."
 
   h.controller.queueFollowUp("wrapped-hyphen", message)
-  assert.deepEqual(h.sent, [`literal:${message}`])
-
-  h.setPane(
-    "",
-    "\u001b[1m›\u001b[0m Call the connector for fray-native-audit/restart-\n  test and wait.\n\n  \u001b[2m100% context left\u001b[0m",
-  )
-  h.controller.tick()
-  assert.deepEqual(h.sent, [`literal:${message}`, "key:Enter"])
+  assert.deepEqual(h.sent, [`atomic:Enter:${message}`])
+  assert.equal(JSON.parse(h.keyQueueSnapshots.at(-1) ?? "[]")[0].state, "submitted")
 })
 
 test("native queued-follow-up ownership requires Codex's local label and the exact queued text", () => {
@@ -692,7 +668,7 @@ test("an old permission completion cannot clear a newer same-session process gen
   assert.equal(saved.control_error, "new generation owns state")
 })
 
-test("durable live Codex follow-up separates typing from idle Enter and clears only on rollout telemetry", () => {
+test("durable live Codex follow-up persists its barrier before atomic paste-and-Enter", () => {
   const h = harness()
   h.storage.upsertSession(row("idle-input"))
   h.storage.setBackend("idle-input", "codex")
@@ -700,13 +676,7 @@ test("durable live Codex follow-up separates typing from idle Enter and clears o
   h.setPane("", emptyComposer)
 
   h.controller.queueFollowUp("idle-input", "Reply exactly IDLE_OK.")
-  assert.deepEqual(h.sent, ["literal:Reply exactly IDLE_OK."])
-  assert.equal(JSON.parse(h.storage.getSession("idle-input")?.codex_input_queue ?? "[]")[0].state, "pending")
-
-  h.sent.length = 0
-  h.setPane("", "\u001b[1m›\u001b[0m Reply exactly IDLE_OK.\n\n  gpt-5.6-sol xhigh · ~/project · Context 71% used")
-  h.controller.tick()
-  assert.deepEqual(h.sent, ["key:Enter"])
+  assert.deepEqual(h.sent, ["atomic:Enter:Reply exactly IDLE_OK."])
   assert.equal(JSON.parse(h.storage.getSession("idle-input")?.codex_input_queue ?? "[]")[0].state, "submitted")
   assert.equal(JSON.parse(h.keyQueueSnapshots.at(-1) ?? "[]")[0].state, "submitted", "barrier is durable before Enter")
 
@@ -723,38 +693,54 @@ test("durable live Codex follow-up separates typing from idle Enter and clears o
   assert.equal(h.storage.getSession("idle-input")?.codex_input_queue, null)
 })
 
-test("an identical two-paragraph Codex draft is submitted instead of blocking its queued follow-up", () => {
+test("an indeterminate atomic-send error preserves the submission barrier and never replays", () => {
+  const h = harness()
+  const slug = "atomic-send-error"
+  h.storage.upsertSession(row(slug))
+  h.storage.setBackend(slug, "codex")
+  h.setTelemetry({ turn: "idle", permPrompt: false, subAgents: [], bgShells: [], pendingQuestion: false })
+  h.setPane("", emptyComposer)
+  h.setAtomicSendSucceeds(false)
+
+  h.controller.queueFollowUp(slug, "SEND_ONCE")
+  assert.deepEqual(h.sent, ["atomic:Enter:SEND_ONCE"])
+  assert.equal(JSON.parse(h.keyQueueSnapshots.at(-1) ?? "[]")[0].state, "submitted")
+  assert.match(h.storage.getSession(slug)?.control_error ?? "", /will not retry/)
+
+  h.setAtomicSendSucceeds(true)
+  h.controller.tick()
+  assert.deepEqual(h.sent, ["atomic:Enter:SEND_ONCE"], "a false return may follow an accepted tmux queue and cannot be retried")
+  assert.equal(JSON.parse(h.storage.getSession(slug)?.codex_input_queue ?? "[]")[0].state, "submitted")
+})
+
+test("a two-paragraph follow-up is atomically pasted and submitted from an empty composer", () => {
   const h = harness()
   const slug = "multi-paragraph-input"
   const message = "Do not keep legacy code around.\n\nImplement this all fully."
   h.storage.upsertSession(row(slug))
   h.storage.setBackend(slug, "codex")
   h.setTelemetry({ turn: "idle", permPrompt: false, subAgents: [], bgShells: [], pendingQuestion: false })
-  h.setPane(
-    "",
-    "\u001b[0;1m›\u001b[0m Do not keep legacy code around.\n\n  Implement this all fully.\n\n  gpt-5.6-sol xhigh · ~/project · Context 71% used",
-    2,
-  )
+  h.setPane("", emptyComposer)
 
   h.controller.queueFollowUp(slug, message)
 
-  assert.deepEqual(h.sent, ["key:Enter"])
+  assert.deepEqual(h.sent, [`atomic:Enter:${message}`])
   assert.equal(h.storage.getSession(slug)?.control_error, null)
   assert.equal(JSON.parse(h.storage.getSession(slug)?.codex_input_queue ?? "[]")[0].state, "submitted")
 })
 
-test("a cursor-bounded footer-like final paragraph cannot auto-submit only its queued prefix", () => {
+test("an ambiguous footer-like final paragraph cannot auto-submit only its queued prefix", () => {
   const h = harness()
   const slug = "footer-like-user-text"
   h.storage.upsertSession(row(slug))
   h.storage.setBackend(slug, "codex")
   h.setTelemetry({ turn: "idle", permPrompt: false, subAgents: [], bgShells: [], pendingQuestion: false })
-  h.setPane("", "\u001b[0;1m›\u001b[0m SAFE\n\n  gpt-5.6-sol xhigh · ~/project · Context 71% used", 2)
+  h.setPane("", "\u001b[0;1m›\u001b[0m SAFE\n\n  gpt-5.6-sol xhigh · ~/project · Context 71% used")
 
   h.controller.queueFollowUp(slug, "SAFE")
 
   assert.deepEqual(h.sent, [])
-  assert.match(h.storage.getSession(slug)?.control_error ?? "", /existing Codex terminal draft/)
+  assert.match(h.storage.getSession(slug)?.control_error ?? "", /ambiguous Codex composer/)
   assert.equal(JSON.parse(h.storage.getSession(slug)?.codex_input_queue ?? "[]")[0].state, "pending")
 })
 
@@ -772,7 +758,7 @@ test("a scheduler delivery id makes durable Codex wake enqueue idempotent", () =
   const queue = JSON.parse(h.storage.getSession(slug)?.codex_input_queue ?? "[]")
   assert.equal(queue.length, 1)
   assert.equal(queue[0].deliveryId, "wake-1")
-  assert.deepEqual(h.sent, [`literal:${message}`], "the duplicate acceptance never types or queues twice")
+  assert.deepEqual(h.sent, [`atomic:Enter:${message}`], "the duplicate acceptance never sends twice")
   assert.throws(
     () => h.controller.queueFollowUp(slug, "different payload", "wake-1"),
     /reused with different input/,
@@ -783,16 +769,12 @@ test("an active Codex composer uses its verified Tab queue hint, never Enter", (
   const h = harness()
   h.storage.upsertSession(row("active-input"))
   h.storage.setBackend("active-input", "codex")
-  h.setPane("", emptyComposer)
-  h.controller.queueFollowUp("active-input", "ACTIVE_FOLLOWUP exact text")
-
-  h.sent.length = 0
   h.setPane(
     "",
-    "\u001b[1m›\u001b[0m ACTIVE_FOLLOWUP exact text\n\n  \u001b[2mtab to queue message\u001b[0m  100% context left",
+    "\u001b[1m›\u001b[0m \u001b[2mAdd a follow-up\u001b[0m\n\n  \u001b[2mtab to queue message\u001b[0m",
   )
-  h.controller.tick()
-  assert.deepEqual(h.sent, ["key:Tab"])
+  h.controller.queueFollowUp("active-input", "ACTIVE_FOLLOWUP exact text")
+  assert.deepEqual(h.sent, ["atomic:Tab:ACTIVE_FOLLOWUP exact text"])
   assert.equal(JSON.parse(h.keyQueueSnapshots.at(-1) ?? "[]")[0].state, "submitted", "barrier is durable before Tab")
 })
 
@@ -814,14 +796,15 @@ test("a queued follow-up waits behind a native tool modal and resumes only after
 
   h.controller.queueFollowUp("modal-input", "continue after the approval")
   assert.deepEqual(h.sent, [], "the controller never answers or types through the modal")
-  assert.match(h.storage.getSession("modal-input")?.control_error ?? "", /current Codex modal/)
+  assert.match(h.storage.getSession("modal-input")?.control_error ?? "", /Codex composer or modal/)
   assert.equal(JSON.parse(h.storage.getSession("modal-input")?.codex_input_queue ?? "[]")[0].state, "pending")
 
   // The human presses Escape/Cancel in Terminal. On the next controller tick, the verified empty
   // composer is available again and the durable follow-up resumes without any replayed modal key.
+  h.setTelemetry({ turn: "idle", permPrompt: false, subAgents: [], bgShells: [], pendingQuestion: false })
   h.setPane("", emptyComposer)
   h.controller.tick()
-  assert.deepEqual(h.sent, ["literal:continue after the approval"])
+  assert.deepEqual(h.sent, ["atomic:Enter:continue after the approval"])
   assert.equal(h.storage.getSession("modal-input")?.control_error, null)
 })
 
@@ -834,10 +817,9 @@ test("identical consecutive follow-ups each require their own post-submission ro
 
   h.setNow(1_000)
   h.controller.queueFollowUp("duplicate-input", "SAME")
-  h.setPane("", "\u001b[1m›\u001b[0m SAME\n\n  gpt-5.6-sol xhigh · ~/project · Context 71% used")
   h.setNow(1_050)
   h.controller.queueFollowUp("duplicate-input", "SAME")
-  assert.deepEqual(h.sent, ["literal:SAME", "key:Enter"])
+  assert.deepEqual(h.sent, ["atomic:Enter:SAME"])
 
   h.setTelemetry({
     turn: "idle",
@@ -856,11 +838,10 @@ test("identical consecutive follow-ups each require their own post-submission ro
   h.setPane("", emptyComposer)
   h.setNow(1_300)
   h.controller.tick()
-  h.setPane("", "\u001b[1m›\u001b[0m SAME\n\n  gpt-5.6-sol xhigh · ~/project · Context 71% used")
-  h.setNow(1_400)
-  h.controller.tick()
+  assert.deepEqual(h.sent, ["atomic:Enter:SAME", "atomic:Enter:SAME"])
   queue = JSON.parse(h.storage.getSession("duplicate-input")?.codex_input_queue ?? "[]")
-  assert.equal(queue[0].submittedAt, "1970-01-01T00:00:01.400Z")
+  assert.equal(queue[0].state, "submitted")
+  assert.equal(queue[0].submittedAt, "1970-01-01T00:00:01.300Z")
 
   h.controller.tick()
   assert.equal(
@@ -944,9 +925,10 @@ test("explicit idle recovery submits the verified existing draft first, confirms
   assert.deepEqual(queue.map((item: { text: string }) => item.text), ["queued after recovery"])
   assert.deepEqual(h.sent, [], "the next message never shares the recovery-confirmation tick")
 
+  h.setTelemetry({ turn: "idle", permPrompt: false, subAgents: [], bgShells: [], pendingQuestion: false })
   h.setPane("", emptyComposer)
   h.controller.tick()
-  assert.deepEqual(h.sent, ["literal:queued after recovery"])
+  assert.deepEqual(h.sent, ["atomic:Enter:queued after recovery"])
 })
 
 test("explicit active recovery uses only Codex's advertised Tab queue control", () => {

--- a/ui/packages/server/src/permission-controller.ts
+++ b/ui/packages/server/src/permission-controller.ts
@@ -20,10 +20,12 @@ export interface PermissionTerminal {
   paneIdentity?(slug: string): tmux.PaneIdentity | null
   capturePane(slug: string): string
   capturePaneEscaped(slug: string): string
+  capturePaneEscapedWithCursor?(slug: string): tmux.PaneTextCapture | null
   sendLiteral(slug: string, text: string): void
   sendKey(slug: string, key: "Enter" | "Tab" | "Up" | "Down" | "Escape"): void
   findExpectedAdoptionPane?(expected: tmux.ExpectedAdoptionPane): tmux.AdoptionPaneLookup
   captureExpectedAdoptionPane?(expected: tmux.ExpectedAdoptionPane, escaped?: boolean): tmux.ExactPaneCapture
+  captureExpectedAdoptionPaneWithCursor?(expected: tmux.ExpectedAdoptionPane): tmux.ExactPaneCursorCapture
   sendTextToExpectedAdoptionPane?(expected: tmux.ExpectedAdoptionPane, text: string, submit: boolean): boolean
   sendKeyToExpectedAdoptionPane?(
     expected: tmux.ExpectedAdoptionPane,
@@ -142,10 +144,12 @@ type CodexComposerCapture =
   | { kind: "typed"; parts: string[]; queueHint: boolean }
   | { kind: "unavailable" }
 
+const codexDimAnsi = /\x1b\[(?:\d+;)*2(?:;\d+)*m/
+
 // Capture only Codex's LAST bold composer prompt. Keeping the visual rows lets the durable-input
 // controller distinguish content from Codex's own width-dependent line breaks without treating an
 // arbitrary difference inside a row as equivalent.
-function captureCodexComposer(escapedPane: string): CodexComposerCapture {
+function captureCodexComposer(escapedPane: string, cursorY?: number): CodexComposerCapture {
   const lines = escapedPane.split("\n")
   for (let i = lines.length - 1; i >= 0; i--) {
     // Codex emits both SGR `1` and the equivalent reset-plus-bold `0;1` across redraws.
@@ -155,10 +159,15 @@ function captureCodexComposer(escapedPane: string): CodexComposerCapture {
     const raw = lines[i].slice(marker.index + marker[0].length)
     if (/^\s*\x1b\[2m/.test(raw)) return { kind: "empty" }
     const parts = [stripAnsi(raw).trim()]
-    for (let j = i + 1; j < lines.length; j++) {
+    const cursorBound = Number.isInteger(cursorY) && cursorY! >= i && cursorY! < lines.length
+      ? cursorY!
+      : undefined
+    for (let j = i + 1; j < lines.length && (cursorBound === undefined || j <= cursorBound); j++) {
       const part = stripAnsi(lines[j]).trim()
-      if (!part) break
-      if (part.includes("tab to queue message") || part.includes("context left")) break
+      if (!part) {
+        if (cursorBound === undefined) break
+        continue
+      }
       parts.push(part)
     }
     return {
@@ -168,17 +177,18 @@ function captureCodexComposer(escapedPane: string): CodexComposerCapture {
       // footer after this (last) composer marker, never a global plain-text match.
       queueHint: lines.slice(i + 1).some((line) => {
         const plain = stripAnsi(line).trimStart()
-        return /\x1b\[(?:\d+;)*2(?:;\d+)*m/.test(line) && plain.startsWith("tab to queue message")
+        return codexDimAnsi.test(line) && plain.startsWith("tab to queue message")
       }),
     }
   }
   return { kind: "unavailable" }
 }
 
-// Inspect only Codex's bold composer prompt. Empty suggestions are dim; real typed text is not. A
-// wrapped draft continues on indented rows until the blank line before the footer.
-export function inspectCodexComposer(escapedPane: string): CodexComposerState {
-  const captured = captureCodexComposer(escapedPane)
+// Inspect only Codex's bold composer prompt. Empty suggestions are dim; real typed text is not.
+// Cursor-aware captures retain every visual row through the live composer cursor; legacy captures
+// stop at the first blank and therefore fail closed for multi-paragraph drafts.
+export function inspectCodexComposer(escapedPane: string, cursorY?: number): CodexComposerState {
+  const captured = captureCodexComposer(escapedPane, cursorY)
   if (captured.kind !== "typed") return captured
   const { parts, queueHint } = captured
     // Codex reflows a draft to the pane width. Ordinary continuation rows break at whitespace, but
@@ -203,8 +213,8 @@ export function inspectCodexComposer(escapedPane: string): CodexComposerState {
 // soft row break. Every boundary may represent either zero characters (a token split) or one
 // normalized whitespace character (a word/newline break); differences anywhere INSIDE a row still
 // fail closed. The position-set DP is linear in practice and cannot explode as 2^rows.
-export function codexComposerMatches(escapedPane: string, expected: string): boolean {
-  const captured = captureCodexComposer(escapedPane)
+export function codexComposerMatches(escapedPane: string, expected: string, cursorY?: number): boolean {
+  const captured = captureCodexComposer(escapedPane, cursorY)
   if (captured.kind !== "typed" || captured.parts.length === 0) return false
   const target = normalizedInput(expected)
   const parts = captured.parts.map(normalizedInput)
@@ -289,10 +299,12 @@ export function createPermissionController(deps: PermissionControllerDeps): Perm
     isLive: tmux.isLive,
     capturePane: tmux.capturePane,
     capturePaneEscaped: tmux.capturePaneEscaped,
+    capturePaneEscapedWithCursor: tmux.capturePaneEscapedWithCursor,
     sendLiteral: tmux.sendLiteral,
     sendKey: tmux.sendKey,
     findExpectedAdoptionPane: tmux.findExpectedAdoptionPane,
     captureExpectedAdoptionPane: tmux.captureExpectedAdoptionPane,
+    captureExpectedAdoptionPaneWithCursor: tmux.captureExpectedAdoptionPaneWithCursor,
     sendTextToExpectedAdoptionPane: tmux.sendTextToExpectedAdoptionPane,
     sendKeyToExpectedAdoptionPane: tmux.sendKeyToExpectedAdoptionPane,
   }
@@ -320,6 +332,20 @@ export function createPermissionController(deps: PermissionControllerDeps): Perm
     }
     const captured = terminal.captureExpectedAdoptionPane?.(binding.claim, escaped)
     return captured?.kind === "captured" ? captured.text : undefined
+  }
+
+  function captureCodexOwned(row: SessionRow): { text: string; cursorY?: number } | undefined {
+    const binding = adoptionRuntimeBinding(deps.storage, row)
+    if (binding.kind === "conflict") return undefined
+    if (binding.kind === "unbound") {
+      if (!terminal.isLive(row.slug)) return undefined
+      const captured = terminal.capturePaneEscapedWithCursor?.(row.slug)
+      return captured ?? { text: terminal.capturePaneEscaped(row.slug) }
+    }
+    const captured = terminal.captureExpectedAdoptionPaneWithCursor?.(binding.claim)
+    if (captured?.kind === "captured") return captured
+    const fallback = terminal.captureExpectedAdoptionPane?.(binding.claim, true)
+    return fallback?.kind === "captured" ? { text: fallback.text } : undefined
   }
 
   function sendLiteralOwned(row: SessionRow, text: string): boolean {
@@ -447,12 +473,13 @@ export function createPermissionController(deps: PermissionControllerDeps): Perm
       throw new Error("Durable Codex input state is invalid; clear or repair it before submitting the draft")
     }
     row = ownCodexInput(row)
-    const escaped = captureOwned(row, true) ?? ""
+    const captured = captureCodexOwned(row)
+    const escaped = captured?.text ?? ""
     const pane = stripAnsi(escaped || captureOwned(row, false) || "")
     if (pane.includes("Press enter to confirm or esc to go back")) {
       throw new Error("Codex is showing a modal; resolve it in Terminal before submitting the draft")
     }
-    const composer = inspectCodexComposer(escaped)
+    const composer = inspectCodexComposer(escaped, captured?.cursorY)
     if (composer.kind !== "typed" || !composer.text) throw new Error("No nonempty Codex terminal draft is available to submit")
 
     const tele = deps.tailer.get(slug)
@@ -497,8 +524,8 @@ export function createPermissionController(deps: PermissionControllerDeps): Perm
     if (!queued || queued.state !== "pending" || queued.source === "existing-draft") {
       throw new Error("No pending Codex follow-up is available for terminal replacement")
     }
-    const escaped = captureOwned(row, true) ?? ""
-    const composer = inspectCodexComposer(escaped)
+    const captured = captureCodexOwned(row)
+    const composer = inspectCodexComposer(captured?.text ?? "", captured?.cursorY)
     if (composer.kind !== "typed" || !composer.text) {
       throw new Error("The existing Codex terminal draft changed; refresh and inspect Terminal before replacing it")
     }
@@ -667,8 +694,9 @@ export function createPermissionController(deps: PermissionControllerDeps): Perm
       failRequest(slug, "Wait for the queued Codex input to finish before changing permissions")
     }
 
+    const codexCapture = row.backend === "codex" ? captureCodexOwned(row) : undefined
     const composer = row.backend === "codex"
-      ? inspectCodexComposer(captureOwned(row, true) ?? "")
+      ? inspectCodexComposer(codexCapture?.text ?? "", codexCapture?.cursorY)
       : inspectClaudeComposer(captureOwned(row, false) ?? "")
     if (composer.kind === "typed") {
       failRequest(slug, `Permission change blocked: submit or clear the existing ${row.backend === "codex" ? "Codex" : "Claude"} terminal draft`)
@@ -852,8 +880,9 @@ export function createPermissionController(deps: PermissionControllerDeps): Perm
     }
     if (item.state === "submitted") return true
 
-    const escaped = captureOwned(row, true) ?? ""
-    const composer = inspectCodexComposer(escaped)
+    const captured = captureCodexOwned(row)
+    const escaped = captured?.text ?? ""
+    const composer = inspectCodexComposer(escaped, captured?.cursorY)
     if (composer.kind === "empty") {
       setError(slug, null)
       if (!sendLiteralOwned(row, item.text)) {
@@ -861,7 +890,7 @@ export function createPermissionController(deps: PermissionControllerDeps): Perm
       }
       return true
     }
-    if (composer.kind === "typed" && codexComposerMatches(escaped, item.text)) {
+    if (composer.kind === "typed" && codexComposerMatches(escaped, item.text, captured?.cursorY)) {
       const tele = deps.tailer.get(slug)
       const key = composer.queueHint ? "Tab" : tele?.turn === "idle" ? "Enter" : undefined
       if (!key) {

--- a/ui/packages/server/src/permission-controller.ts
+++ b/ui/packages/server/src/permission-controller.ts
@@ -20,13 +20,13 @@ export interface PermissionTerminal {
   paneIdentity?(slug: string): tmux.PaneIdentity | null
   capturePane(slug: string): string
   capturePaneEscaped(slug: string): string
-  capturePaneEscapedWithCursor?(slug: string): tmux.PaneTextCapture | null
   sendLiteral(slug: string, text: string): void
+  sendTextWithKey?(slug: string, text: string, key: "Enter" | "Tab"): boolean
   sendKey(slug: string, key: "Enter" | "Tab" | "Up" | "Down" | "Escape"): void
   findExpectedAdoptionPane?(expected: tmux.ExpectedAdoptionPane): tmux.AdoptionPaneLookup
   captureExpectedAdoptionPane?(expected: tmux.ExpectedAdoptionPane, escaped?: boolean): tmux.ExactPaneCapture
-  captureExpectedAdoptionPaneWithCursor?(expected: tmux.ExpectedAdoptionPane): tmux.ExactPaneCursorCapture
   sendTextToExpectedAdoptionPane?(expected: tmux.ExpectedAdoptionPane, text: string, submit: boolean): boolean
+  sendTextWithKeyToExpectedAdoptionPane?(expected: tmux.ExpectedAdoptionPane, text: string, key: "Enter" | "Tab"): boolean
   sendKeyToExpectedAdoptionPane?(
     expected: tmux.ExpectedAdoptionPane,
     key: "Enter" | "Tab" | "Up" | "Down" | "Escape",
@@ -145,11 +145,36 @@ type CodexComposerCapture =
   | { kind: "unavailable" }
 
 const codexDimAnsi = /\x1b\[(?:\d+;)*2(?:;\d+)*m/
+const codexModelFooter = /^(?:gpt-[\w.-]+|o\d[\w.-]*)(?:\s+(?:low|medium|high|xhigh|max|ultra|default))?\s+·\s+\S+/i
+
+function isCodexDimFooter(line: string): boolean {
+  const plain = stripAnsi(line).trim()
+  return codexDimAnsi.test(line) && (
+    /^tab to queue message\b/i.test(plain) ||
+    /^\d+%\s+context left\b/i.test(plain)
+  )
+}
+
+function isCodexStyledModelFooter(line: string): boolean {
+  return /\x1b\[/.test(line) && codexModelFooter.test(stripAnsi(line).trim())
+}
+
+function codexQueueHint(escapedPane: string): boolean {
+  const lines = escapedPane.split("\n")
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (!/\x1b\[(?:0;)?1m›\x1b\[0m/.test(lines[i])) continue
+    return lines.slice(i + 1).some((line) => {
+      const plain = stripAnsi(line).trimStart()
+      return codexDimAnsi.test(line) && plain.startsWith("tab to queue message")
+    })
+  }
+  return false
+}
 
 // Capture only Codex's LAST bold composer prompt. Keeping the visual rows lets the durable-input
 // controller distinguish content from Codex's own width-dependent line breaks without treating an
 // arbitrary difference inside a row as equivalent.
-function captureCodexComposer(escapedPane: string, cursorY?: number): CodexComposerCapture {
+function captureCodexComposer(escapedPane: string): CodexComposerCapture {
   const lines = escapedPane.split("\n")
   for (let i = lines.length - 1; i >= 0; i--) {
     // Codex emits both SGR `1` and the equivalent reset-plus-bold `0;1` across redraws.
@@ -159,14 +184,14 @@ function captureCodexComposer(escapedPane: string, cursorY?: number): CodexCompo
     const raw = lines[i].slice(marker.index + marker[0].length)
     if (/^\s*\x1b\[2m/.test(raw)) return { kind: "empty" }
     const parts = [stripAnsi(raw).trim()]
-    const cursorBound = Number.isInteger(cursorY) && cursorY! >= i && cursorY! < lines.length
-      ? cursorY!
-      : undefined
-    for (let j = i + 1; j < lines.length && (cursorBound === undefined || j <= cursorBound); j++) {
+    for (let j = i + 1; j < lines.length; j++) {
       const part = stripAnsi(lines[j]).trim()
       if (!part) {
-        if (cursorBound === undefined) break
-        continue
+        const footer = lines.slice(j + 1).filter((line) => stripAnsi(line).trim())
+        if (!footer.every((line) => isCodexDimFooter(line) || isCodexStyledModelFooter(line))) {
+          return { kind: "unavailable" }
+        }
+        break
       }
       parts.push(part)
     }
@@ -175,20 +200,16 @@ function captureCodexComposer(escapedPane: string, cursorY?: number): CodexCompo
       parts,
       // The phrase can occur in transcript history or in the user's draft. Trust only Codex's dim
       // footer after this (last) composer marker, never a global plain-text match.
-      queueHint: lines.slice(i + 1).some((line) => {
-        const plain = stripAnsi(line).trimStart()
-        return codexDimAnsi.test(line) && plain.startsWith("tab to queue message")
-      }),
+      queueHint: codexQueueHint(escapedPane),
     }
   }
   return { kind: "unavailable" }
 }
 
 // Inspect only Codex's bold composer prompt. Empty suggestions are dim; real typed text is not.
-// Cursor-aware captures retain every visual row through the live composer cursor; legacy captures
-// stop at the first blank and therefore fail closed for multi-paragraph drafts.
-export function inspectCodexComposer(escapedPane: string, cursorY?: number): CodexComposerState {
-  const captured = captureCodexComposer(escapedPane, cursorY)
+// Plain text after a paragraph gap is ambiguous with Codex's unstyled footer, so it fails closed.
+export function inspectCodexComposer(escapedPane: string): CodexComposerState {
+  const captured = captureCodexComposer(escapedPane)
   if (captured.kind !== "typed") return captured
   const { parts, queueHint } = captured
     // Codex reflows a draft to the pane width. Ordinary continuation rows break at whitespace, but
@@ -213,8 +234,8 @@ export function inspectCodexComposer(escapedPane: string, cursorY?: number): Cod
 // soft row break. Every boundary may represent either zero characters (a token split) or one
 // normalized whitespace character (a word/newline break); differences anywhere INSIDE a row still
 // fail closed. The position-set DP is linear in practice and cannot explode as 2^rows.
-export function codexComposerMatches(escapedPane: string, expected: string, cursorY?: number): boolean {
-  const captured = captureCodexComposer(escapedPane, cursorY)
+export function codexComposerMatches(escapedPane: string, expected: string): boolean {
+  const captured = captureCodexComposer(escapedPane)
   if (captured.kind !== "typed" || captured.parts.length === 0) return false
   const target = normalizedInput(expected)
   const parts = captured.parts.map(normalizedInput)
@@ -299,13 +320,13 @@ export function createPermissionController(deps: PermissionControllerDeps): Perm
     isLive: tmux.isLive,
     capturePane: tmux.capturePane,
     capturePaneEscaped: tmux.capturePaneEscaped,
-    capturePaneEscapedWithCursor: tmux.capturePaneEscapedWithCursor,
     sendLiteral: tmux.sendLiteral,
+    sendTextWithKey: tmux.sendTextWithKey,
     sendKey: tmux.sendKey,
     findExpectedAdoptionPane: tmux.findExpectedAdoptionPane,
     captureExpectedAdoptionPane: tmux.captureExpectedAdoptionPane,
-    captureExpectedAdoptionPaneWithCursor: tmux.captureExpectedAdoptionPaneWithCursor,
     sendTextToExpectedAdoptionPane: tmux.sendTextToExpectedAdoptionPane,
+    sendTextWithKeyToExpectedAdoptionPane: tmux.sendTextWithKeyToExpectedAdoptionPane,
     sendKeyToExpectedAdoptionPane: tmux.sendKeyToExpectedAdoptionPane,
   }
   const now = deps.now ?? Date.now
@@ -334,29 +355,14 @@ export function createPermissionController(deps: PermissionControllerDeps): Perm
     return captured?.kind === "captured" ? captured.text : undefined
   }
 
-  function captureCodexOwned(row: SessionRow): { text: string; cursorY?: number } | undefined {
-    const binding = adoptionRuntimeBinding(deps.storage, row)
-    if (binding.kind === "conflict") return undefined
-    if (binding.kind === "unbound") {
-      if (!terminal.isLive(row.slug)) return undefined
-      const captured = terminal.capturePaneEscapedWithCursor?.(row.slug)
-      return captured ?? { text: terminal.capturePaneEscaped(row.slug) }
-    }
-    const captured = terminal.captureExpectedAdoptionPaneWithCursor?.(binding.claim)
-    if (captured?.kind === "captured") return captured
-    const fallback = terminal.captureExpectedAdoptionPane?.(binding.claim, true)
-    return fallback?.kind === "captured" ? { text: fallback.text } : undefined
-  }
-
-  function sendLiteralOwned(row: SessionRow, text: string): boolean {
+  function sendTextWithKeyOwned(row: SessionRow, text: string, key: "Enter" | "Tab"): boolean {
     const binding = adoptionRuntimeBinding(deps.storage, row)
     if (binding.kind === "conflict") return false
     if (binding.kind === "bound") {
-      return terminal.sendTextToExpectedAdoptionPane?.(binding.claim, text, false) === true
+      return terminal.sendTextWithKeyToExpectedAdoptionPane?.(binding.claim, text, key) === true
     }
     if (!terminal.isLive(row.slug)) return false
-    terminal.sendLiteral(row.slug, text)
-    return true
+    return terminal.sendTextWithKey?.(row.slug, text, key) === true
   }
 
   function sendKeyOwned(
@@ -473,13 +479,12 @@ export function createPermissionController(deps: PermissionControllerDeps): Perm
       throw new Error("Durable Codex input state is invalid; clear or repair it before submitting the draft")
     }
     row = ownCodexInput(row)
-    const captured = captureCodexOwned(row)
-    const escaped = captured?.text ?? ""
+    const escaped = captureOwned(row, true) ?? ""
     const pane = stripAnsi(escaped || captureOwned(row, false) || "")
     if (pane.includes("Press enter to confirm or esc to go back")) {
       throw new Error("Codex is showing a modal; resolve it in Terminal before submitting the draft")
     }
-    const composer = inspectCodexComposer(escaped, captured?.cursorY)
+    const composer = inspectCodexComposer(escaped)
     if (composer.kind !== "typed" || !composer.text) throw new Error("No nonempty Codex terminal draft is available to submit")
 
     const tele = deps.tailer.get(slug)
@@ -524,8 +529,8 @@ export function createPermissionController(deps: PermissionControllerDeps): Perm
     if (!queued || queued.state !== "pending" || queued.source === "existing-draft") {
       throw new Error("No pending Codex follow-up is available for terminal replacement")
     }
-    const captured = captureCodexOwned(row)
-    const composer = inspectCodexComposer(captured?.text ?? "", captured?.cursorY)
+    const escaped = captureOwned(row, true) ?? ""
+    const composer = inspectCodexComposer(escaped)
     if (composer.kind !== "typed" || !composer.text) {
       throw new Error("The existing Codex terminal draft changed; refresh and inspect Terminal before replacing it")
     }
@@ -694,9 +699,8 @@ export function createPermissionController(deps: PermissionControllerDeps): Perm
       failRequest(slug, "Wait for the queued Codex input to finish before changing permissions")
     }
 
-    const codexCapture = row.backend === "codex" ? captureCodexOwned(row) : undefined
     const composer = row.backend === "codex"
-      ? inspectCodexComposer(codexCapture?.text ?? "", codexCapture?.cursorY)
+      ? inspectCodexComposer(captureOwned(row, true) ?? "")
       : inspectClaudeComposer(captureOwned(row, false) ?? "")
     if (composer.kind === "typed") {
       failRequest(slug, `Permission change blocked: submit or clear the existing ${row.backend === "codex" ? "Codex" : "Claude"} terminal draft`)
@@ -816,7 +820,8 @@ export function createPermissionController(deps: PermissionControllerDeps): Perm
   }
 
   // Returns true while a queued input owns or is waiting for the composer; a permission reattach must
-  // stay behind it. Literal text and the submit key intentionally happen on separate ticks.
+  // stay behind it. New input is pasted and submitted by one tmux command queue after its durable
+  // barrier is written, so Fray never has to rediscover its own multiline draft from screen text.
   function tickInput(slug: string): boolean {
     let row = deps.storage.getSession(slug)
     if (!row) return false
@@ -880,17 +885,27 @@ export function createPermissionController(deps: PermissionControllerDeps): Perm
     }
     if (item.state === "submitted") return true
 
-    const captured = captureCodexOwned(row)
-    const escaped = captured?.text ?? ""
-    const composer = inspectCodexComposer(escaped, captured?.cursorY)
+    const escaped = captureOwned(row, true) ?? ""
+    const composer = inspectCodexComposer(escaped)
     if (composer.kind === "empty") {
+      const tele = deps.tailer.get(slug)
+      const key = codexQueueHint(escaped) ? "Tab" : tele?.turn === "idle" ? "Enter" : undefined
+      if (!key) {
+        setError(slug, "Queued Codex message is waiting for an idle or queueable composer")
+        return true
+      }
+      // Persist the barrier before one tmux command queue pastes the complete message and submits it.
+      // Fray never leaves its own draft behind for a later content-based guess.
+      item.state = "submitted"
+      item.submittedAt = new Date(now()).toISOString()
+      writeQueue(slug, queue, row)
       setError(slug, null)
-      if (!sendLiteralOwned(row, item.text)) {
-        setError(slug, "Queued Codex message was not staged because the worker identity changed")
+      if (!sendTextWithKeyOwned(row, item.text, key)) {
+        setError(slug, "Queued Codex submission could not be confirmed; Fray will not retry it automatically")
       }
       return true
     }
-    if (composer.kind === "typed" && codexComposerMatches(escaped, item.text, captured?.cursorY)) {
+    if (composer.kind === "typed" && codexComposerMatches(escaped, item.text)) {
       const tele = deps.tailer.get(slug)
       const key = composer.queueHint ? "Tab" : tele?.turn === "idle" ? "Enter" : undefined
       if (!key) {
@@ -912,7 +927,7 @@ export function createPermissionController(deps: PermissionControllerDeps): Perm
       setError(slug, "Queued message blocked: submit or clear the existing Codex terminal draft")
       return true
     }
-    setError(slug, "Queued message blocked by the current Codex modal; resolve it in Terminal")
+    setError(slug, "Queued message blocked by an ambiguous Codex composer or modal; resolve it in Terminal")
     return true
   }
 

--- a/ui/packages/server/src/tmux.test.ts
+++ b/ui/packages/server/src/tmux.test.ts
@@ -19,9 +19,9 @@ import {
   findPaneIdentity,
   findExpectedAdoptionPane,
   captureExpectedAdoptionPane,
-  captureExpectedAdoptionPaneWithCursor,
-  capturePaneEscapedWithCursor,
   crossSocketLiveOwner,
+  sendTextWithKey,
+  sendTextWithKeyToExpectedAdoptionPane,
   sendTextToExpectedAdoptionPane,
   expectedAdoptionAttachArgs,
   isExpectedAdoptionPaneLiveAnywhereCached,
@@ -146,8 +146,6 @@ test("new-session atomically exposes the adoption token with its exact pane gene
     )
     const bySlug = lookupAdoptionPane(slug)
     const byToken = findAdoptionPane(token)
-    const capture = capturePaneEscapedWithCursor(slug)
-    assert.ok(capture && Number.isInteger(capture.cursorY), "cursor-aware capture returns pane text and its cursor row")
     assert.equal(bySlug.kind, "found")
     assert.equal(byToken.kind, "found")
     if (bySlug.kind === "found" && byToken.kind === "found") {
@@ -214,10 +212,7 @@ test("exact adoption control is atomic, survives rename, and never contacts a re
     assert.equal(findExpectedAdoptionPane(expected).kind, "found", "global token + tuple still find the renamed owner")
     assert.equal(isExpectedAdoptionPaneLiveAnywhereCached(expected), true)
     assert.equal(captureExpectedAdoptionPane(expected).kind, "captured")
-    const cursorCapture = captureExpectedAdoptionPaneWithCursor(expected)
-    assert.equal(cursorCapture.kind, "captured")
-    if (cursorCapture.kind === "captured") assert.ok(Number.isInteger(cursorCapture.cursorY))
-    assert.equal(sendTextToExpectedAdoptionPane(expected, "hello-owner", true), true)
+    assert.equal(sendTextWithKeyToExpectedAdoptionPane(expected, "hello-owner", "Enter"), true)
 
     const competitor = spawn(
       slug,
@@ -306,7 +301,7 @@ test("token + full tuple teardown is one atomic authorization, including dead pa
   }
 })
 
-test("exact text send leaves no secret-bearing tmux buffer on success, mismatch, or server error", { skip: !tmuxAvailable }, () => {
+test("atomic text-and-key sends leave no secret-bearing tmux buffer on success, mismatch, or server error", { skip: !tmuxAvailable }, () => {
   const originalSocket = socketName()
   const slug = `exact-buffer-${process.pid}`
   const token = randomUUID()
@@ -345,8 +340,17 @@ test("exact text send leaves no secret-bearing tmux buffer on success, mismatch,
     assert.doesNotMatch(buffers(), /fray-exact-/)
     assert.doesNotMatch(buffers(), new RegExp(secret))
 
+    assert.equal(sendTextWithKeyToExpectedAdoptionPane(expected, secret, "Tab"), true)
+    assert.doesNotMatch(buffers(), /fray-exact-/)
+    assert.doesNotMatch(buffers(), new RegExp(secret))
+
+    assert.equal(sendTextWithKeyToExpectedAdoptionPane({ ...expected, attempt_token: randomUUID() }, secret, "Enter"), false)
+    assert.doesNotMatch(buffers(), /fray-exact-/)
+    assert.doesNotMatch(buffers(), new RegExp(secret))
+
     killSession(slug)
     assert.equal(sendTextToExpectedAdoptionPane(expected, secret, false), false)
+    assert.equal(sendTextWithKeyToExpectedAdoptionPane(expected, secret, "Enter"), false)
     assert.doesNotMatch(buffers(), /fray-exact-/)
     assert.doesNotMatch(buffers(), new RegExp(secret))
   } finally {
@@ -355,7 +359,53 @@ test("exact text send leaves no secret-bearing tmux buffer on success, mismatch,
   }
 })
 
-test("SIGKILL during exact text transport cannot strand its private tmux buffer", { skip: !tmuxAvailable }, async () => {
+test("local atomic text-and-key send pastes the complete multiline payload and cleans its private buffer", { skip: !tmuxAvailable }, async () => {
+  const originalSocket = socketName()
+  const slug = `local-atomic-send-${process.pid}`
+  const secret = `FRAY_LOCAL_BUFFER_SECRET_${randomUUID()}`
+  setSocket(`fray-local-atomic-send-test-${process.pid}`)
+  const buffers = (): string => {
+    try {
+      return execFileSync("tmux", ["-L", socketName(), "list-buffers", "-F", "#{buffer_name}\t#{buffer_sample}"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      })
+    } catch {
+      return ""
+    }
+  }
+  try {
+    spawn(
+      slug,
+      [process.execPath, "-e", "process.stdin.on('data', d => process.stdout.write('LOCAL:' + JSON.stringify(d.toString())))"],
+      process.cwd(),
+    )
+    const payload = `${secret} first paragraph\n\nsecond paragraph`
+    assert.equal(sendTextWithKey(slug, payload, "Enter"), true)
+    assert.doesNotMatch(buffers(), /fray-input-/)
+    assert.doesNotMatch(buffers(), new RegExp(secret))
+
+    let pane = ""
+    const deadline = Date.now() + 2_000
+    while (Date.now() < deadline) {
+      pane = execFileSync("tmux", ["-L", socketName(), "capture-pane", "-p", "-t", tmuxSessionName(slug)], { encoding: "utf8" })
+      if (pane.includes(secret) && pane.includes("second paragraph")) break
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    assert.match(pane, new RegExp(secret))
+    assert.match(pane, /second paragraph/)
+
+    killSession(slug)
+    assert.equal(sendTextWithKey(slug, secret, "Enter"), false)
+    assert.doesNotMatch(buffers(), /fray-input-/)
+    assert.doesNotMatch(buffers(), new RegExp(secret))
+  } finally {
+    killSession(slug)
+    setSocket(originalSocket)
+  }
+})
+
+test("SIGKILL during exact atomic text-and-key transport cannot strand its private tmux buffer", { skip: !tmuxAvailable }, async () => {
   const originalSocket = socketName()
   const slug = `exact-buffer-kill-${process.pid}`
   const token = randomUUID()
@@ -373,13 +423,13 @@ test("SIGKILL during exact text transport cannot strand its private tmux buffer"
     }
     const moduleUrl = new URL("./tmux.ts", import.meta.url).href
     const child = spawnChild(process.execPath, ["--input-type=module", "-e", `
-      import { setSocket, sendTextToExpectedAdoptionPane } from ${JSON.stringify(moduleUrl)};
+      import { setSocket, sendTextWithKeyToExpectedAdoptionPane } from ${JSON.stringify(moduleUrl)};
       setSocket(${JSON.stringify(testSocket)});
       process.stdout.write("FRAY_SEND_READY\\n");
-      sendTextToExpectedAdoptionPane(
+      sendTextWithKeyToExpectedAdoptionPane(
         ${JSON.stringify(expected)},
         "FRAY_SIGKILL_BUFFER_SECRET_" + "x".repeat(32 * 1024 * 1024),
-        false,
+        "Enter",
       );
     `], { stdio: ["ignore", "pipe", "pipe"] })
     await new Promise<void>((resolve, reject) => {

--- a/ui/packages/server/src/tmux.test.ts
+++ b/ui/packages/server/src/tmux.test.ts
@@ -19,6 +19,8 @@ import {
   findPaneIdentity,
   findExpectedAdoptionPane,
   captureExpectedAdoptionPane,
+  captureExpectedAdoptionPaneWithCursor,
+  capturePaneEscapedWithCursor,
   crossSocketLiveOwner,
   sendTextToExpectedAdoptionPane,
   expectedAdoptionAttachArgs,
@@ -144,6 +146,8 @@ test("new-session atomically exposes the adoption token with its exact pane gene
     )
     const bySlug = lookupAdoptionPane(slug)
     const byToken = findAdoptionPane(token)
+    const capture = capturePaneEscapedWithCursor(slug)
+    assert.ok(capture && Number.isInteger(capture.cursorY), "cursor-aware capture returns pane text and its cursor row")
     assert.equal(bySlug.kind, "found")
     assert.equal(byToken.kind, "found")
     if (bySlug.kind === "found" && byToken.kind === "found") {
@@ -210,6 +214,9 @@ test("exact adoption control is atomic, survives rename, and never contacts a re
     assert.equal(findExpectedAdoptionPane(expected).kind, "found", "global token + tuple still find the renamed owner")
     assert.equal(isExpectedAdoptionPaneLiveAnywhereCached(expected), true)
     assert.equal(captureExpectedAdoptionPane(expected).kind, "captured")
+    const cursorCapture = captureExpectedAdoptionPaneWithCursor(expected)
+    assert.equal(cursorCapture.kind, "captured")
+    if (cursorCapture.kind === "captured") assert.ok(Number.isInteger(cursorCapture.cursorY))
     assert.equal(sendTextToExpectedAdoptionPane(expected, "hello-owner", true), true)
 
     const competitor = spawn(

--- a/ui/packages/server/src/tmux.test.ts
+++ b/ui/packages/server/src/tmux.test.ts
@@ -377,7 +377,19 @@ test("local atomic text-and-key send pastes the complete multiline payload and c
   try {
     spawn(
       slug,
-      [process.execPath, "-e", "process.stdin.on('data', d => process.stdout.write('LOCAL:' + JSON.stringify(d.toString())))"],
+      [process.execPath, "-e", `
+        process.stdin.setRawMode(true);
+        let sawPayload = false;
+        process.stdin.on('data', d => {
+          const value = d.toString();
+          if (value === '\\r') {
+            process.stdout.write(sawPayload ? 'SUBMIT_AFTER_PASTE' : 'COALESCED_SUBMIT');
+          } else {
+            sawPayload = true;
+            process.stdout.write('PAYLOAD:' + value);
+          }
+        });
+      `],
       process.cwd(),
     )
     const payload = `${secret} first paragraph\n\nsecond paragraph`
@@ -389,11 +401,13 @@ test("local atomic text-and-key send pastes the complete multiline payload and c
     const deadline = Date.now() + 2_000
     while (Date.now() < deadline) {
       pane = execFileSync("tmux", ["-L", socketName(), "capture-pane", "-p", "-t", tmuxSessionName(slug)], { encoding: "utf8" })
-      if (pane.includes(secret) && pane.includes("second paragraph")) break
+      if (pane.includes("first paragraph") && pane.includes("second paragraph") && pane.includes("SUBMIT_AFTER_PASTE")) break
       await new Promise((resolve) => setTimeout(resolve, 10))
     }
-    assert.match(pane, new RegExp(secret))
+    assert.match(pane, /first paragraph/)
     assert.match(pane, /second paragraph/)
+    assert.match(pane, /SUBMIT_AFTER_PASTE/, "the submit key reaches the application in a later input event than the paste")
+    assert.doesNotMatch(pane, /COALESCED_SUBMIT/)
 
     killSession(slug)
     assert.equal(sendTextWithKey(slug, secret, "Enter"), false)
@@ -401,6 +415,141 @@ test("local atomic text-and-key send pastes the complete multiline payload and c
     assert.doesNotMatch(buffers(), new RegExp(secret))
   } finally {
     killSession(slug)
+    setSocket(originalSocket)
+  }
+})
+
+test("a pane replaced during the paste settle boundary receives no delayed key and strands no input buffer", { skip: !tmuxAvailable }, async () => {
+  const originalSocket = socketName()
+  const slug = `local-settle-race-${process.pid}`
+  const holder = `local-settle-holder-${process.pid}`
+  const testSocket = `fray-local-settle-race-test-${process.pid}`
+  setSocket(testSocket)
+  const buffers = (): string => {
+    try {
+      return execFileSync("tmux", ["-L", testSocket, "list-buffers", "-F", "#{buffer_name}"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      })
+    } catch {
+      return ""
+    }
+  }
+  try {
+    spawn(holder, [process.execPath, "-e", "setInterval(() => {}, 1000)"], process.cwd())
+    spawn(slug, [process.execPath, "-e", "process.stdin.resume()"], process.cwd())
+    const moduleUrl = new URL("./tmux.ts", import.meta.url).href
+    let output = ""
+    const child = spawnChild(process.execPath, ["--input-type=module", "-e", `
+      import { setSocket, sendTextWithKey } from ${JSON.stringify(moduleUrl)};
+      setSocket(${JSON.stringify(testSocket)});
+      process.stdout.write("FRAY_SETTLE_READY\\n");
+      const result = sendTextWithKey(${JSON.stringify(slug)}, "MUST_NOT_REACH_REPLACEMENT", "Enter");
+      process.stdout.write("RESULT:" + result + "\\n");
+    `], { stdio: ["ignore", "pipe", "pipe"] })
+    child.stdout.on("data", (chunk) => { output += String(chunk) })
+
+    const bufferDeadline = Date.now() + 2_000
+    while (Date.now() < bufferDeadline && !buffers().includes("fray-input-")) {
+      await new Promise((resolve) => setTimeout(resolve, 1))
+    }
+    assert.match(buffers(), /fray-input-/, "the target is replaced while the server-side settle queue is paused")
+
+    killSession(slug)
+    spawn(slug, [process.execPath, "-e", "process.stdin.on('data', d => process.stdout.write('COMPETITOR:' + d))"], process.cwd())
+    const code = await new Promise<number | null>((resolve) => child.once("close", resolve))
+    assert.equal(code, 0)
+    assert.match(output, /RESULT:false/)
+    assert.doesNotMatch(buffers(), /fray-input-/)
+
+    const competitor = execFileSync(
+      "tmux",
+      ["-L", testSocket, "capture-pane", "-p", "-t", tmuxSessionName(slug)],
+      { encoding: "utf8" },
+    )
+    assert.doesNotMatch(competitor, /MUST_NOT_REACH_REPLACEMENT|COMPETITOR:/)
+  } finally {
+    killSession(slug)
+    killSession(holder)
+    setSocket(originalSocket)
+  }
+})
+
+test("an exact adopted pane replaced during settle receives no delayed key and strands no input buffer", { skip: !tmuxAvailable }, async () => {
+  const originalSocket = socketName()
+  const slug = `exact-settle-race-${process.pid}`
+  const holder = `exact-settle-holder-${process.pid}`
+  const token = randomUUID()
+  const competitorToken = randomUUID()
+  const testSocket = `fray-exact-settle-race-test-${process.pid}`
+  setSocket(testSocket)
+  const buffers = (): string => {
+    try {
+      return execFileSync("tmux", ["-L", testSocket, "list-buffers", "-F", "#{buffer_name}"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      })
+    } catch {
+      return ""
+    }
+  }
+  let exact: ReturnType<typeof spawn> | undefined
+  try {
+    spawn(holder, [process.execPath, "-e", "setInterval(() => {}, 1000)"], process.cwd())
+    exact = spawn(slug, [process.execPath, "-e", "process.stdin.resume()"], process.cwd(), undefined, {
+      adoptionAttemptToken: token,
+    })
+    const expected = {
+      attempt_token: token,
+      pane_id: exact.paneId,
+      pane_pid: exact.panePid,
+      session_created: exact.sessionCreated,
+    }
+    const moduleUrl = new URL("./tmux.ts", import.meta.url).href
+    let output = ""
+    const child = spawnChild(process.execPath, ["--input-type=module", "-e", `
+      import { setSocket, sendTextWithKeyToExpectedAdoptionPane } from ${JSON.stringify(moduleUrl)};
+      setSocket(${JSON.stringify(testSocket)});
+      process.stdout.write("FRAY_EXACT_SETTLE_READY\\n");
+      const result = sendTextWithKeyToExpectedAdoptionPane(
+        ${JSON.stringify(expected)},
+        "MUST_NOT_REACH_EXACT_REPLACEMENT",
+        "Enter",
+      );
+      process.stdout.write("RESULT:" + result + "\\n");
+    `], { stdio: ["ignore", "pipe", "pipe"] })
+    child.stdout.on("data", (chunk) => { output += String(chunk) })
+
+    const bufferDeadline = Date.now() + 2_000
+    while (Date.now() < bufferDeadline && !buffers().includes("fray-exact-")) {
+      await new Promise((resolve) => setTimeout(resolve, 1))
+    }
+    assert.match(buffers(), /fray-exact-/, "the exact owner is replaced while its settle queue is paused")
+
+    killPane(exact)
+    exact = undefined
+    spawn(
+      slug,
+      [process.execPath, "-e", "process.stdin.on('data', d => process.stdout.write('COMPETITOR:' + d))"],
+      process.cwd(),
+      undefined,
+      { adoptionAttemptToken: competitorToken },
+    )
+    const code = await new Promise<number | null>((resolve) => child.once("close", resolve))
+    assert.equal(code, 0)
+    assert.match(output, /RESULT:false/)
+    assert.doesNotMatch(buffers(), /fray-exact-/)
+
+    const competitor = execFileSync(
+      "tmux",
+      ["-L", testSocket, "capture-pane", "-p", "-t", tmuxSessionName(slug)],
+      { encoding: "utf8" },
+    )
+    assert.doesNotMatch(competitor, /MUST_NOT_REACH_EXACT_REPLACEMENT|COMPETITOR:/)
+  } finally {
+    if (exact) killPane(exact)
+    killSession(slug)
+    killSession(holder)
     setSocket(originalSocket)
   }
 })

--- a/ui/packages/server/src/tmux.ts
+++ b/ui/packages/server/src/tmux.ts
@@ -427,37 +427,6 @@ export function capturePaneEscaped(slug: string): string {
   }
 }
 
-const CURSOR_CAPTURE_PREFIX = "FRAY_CURSOR_Y_9A74D2:"
-
-export interface PaneTextCapture {
-  text: string
-  cursorY: number
-}
-
-function parseCursorCapture(out: string, prefix = CURSOR_CAPTURE_PREFIX): PaneTextCapture | null {
-  const newline = out.indexOf("\n")
-  if (newline < 0 || !out.startsWith(prefix)) return null
-  const cursorY = Number(out.slice(prefix.length, newline))
-  return Number.isInteger(cursorY) && cursorY >= 0
-    ? { text: out.slice(newline + 1), cursorY }
-    : null
-}
-
-// Capture the visible escaped pane and cursor row in one tmux command queue. Codex's composer text
-// and footer are visually identical in some releases; the cursor row is the out-of-band boundary
-// that lets the input controller retain intentional blank-line-separated draft paragraphs.
-export function capturePaneEscapedWithCursor(slug: string): PaneTextCapture | null {
-  const name = tmuxSessionName(slug)
-  try {
-    return parseCursorCapture(tmux(
-      "display-message", "-p", "-t", name, `${CURSOR_CAPTURE_PREFIX}#{cursor_y}`,
-      ";", "capture-pane", "-p", "-e", "-t", name,
-    ))
-  } catch {
-    return null
-  }
-}
-
 export interface PaneIdentity {
   paneId: string
   panePid: number
@@ -560,10 +529,6 @@ export type ExactPaneCapture =
   | { kind: "captured"; text: string }
   | { kind: "unavailable" }
 
-export type ExactPaneCursorCapture =
-  | ({ kind: "captured" } & PaneTextCapture)
-  | { kind: "unavailable" }
-
 // Check token + full tuple and capture in one tmux server command. A pane replacement cannot slip
 // between authorization and capture, and a renamed exact owner remains addressable by pane id.
 export function captureExpectedAdoptionPane(
@@ -582,27 +547,6 @@ export function captureExpectedAdoptionPane(
     return out.startsWith(prefix)
       ? { kind: "captured", text: out.slice(prefix.length) }
       : { kind: "unavailable" }
-  } catch {
-    return { kind: "unavailable" }
-  }
-}
-
-// The token + immutable pane tuple and the cursor-aware capture are evaluated by one tmux server
-// command. A renamed adopted worker therefore gets the same composer boundary proof as a local one.
-export function captureExpectedAdoptionPaneWithCursor(
-  expected: ExpectedAdoptionPane,
-): ExactPaneCursorCapture {
-  const condition = expectedAdoptionCondition(expected)
-  if (!condition || expected.pane_id === null) return { kind: "unavailable" }
-  try {
-    const header = `${EXACT_ACTION_OK}:${CURSOR_CAPTURE_PREFIX}`
-    const out = tmux(
-      "if-shell", "-t", expected.pane_id, "-F", condition,
-      `display-message -p '${header}#{cursor_y}' ; capture-pane -p -e -t ${expected.pane_id}`,
-      `display-message -p ${EXACT_ACTION_MISS}`,
-    )
-    const captured = parseCursorCapture(out, header)
-    return captured ? { kind: "captured", ...captured } : { kind: "unavailable" }
   } catch {
     return { kind: "unavailable" }
   }
@@ -638,6 +582,35 @@ export function sendTextToExpectedAdoptionPane(
   } catch {
     // A single tmux client submitted the complete server-side queue. Never retry an ambiguous paste:
     // the server either rejected it before authorization or finishes the queued cleanup itself.
+    return false
+  }
+}
+
+export function sendTextWithKeyToExpectedAdoptionPane(
+  expected: ExpectedAdoptionPane,
+  text: string,
+  key: "Enter" | "Tab",
+): boolean {
+  const condition = expectedAdoptionCondition(expected)
+  if (!condition || expected.pane_id === null) return false
+  const buffer = `fray-exact-${randomUUID()}`
+  try {
+    const out = execFileSync("tmux", [
+      "-L", socket,
+      "load-buffer", "-b", buffer, "-",
+      ";",
+      "if-shell", "-t", expected.pane_id, "-F", condition,
+      `paste-buffer -b ${buffer} -t ${expected.pane_id} ; send-keys -t ${expected.pane_id} ${key} ; display-message -p ${EXACT_ACTION_OK}`,
+      `display-message -p ${EXACT_ACTION_MISS}`,
+      ";",
+      "delete-buffer", "-b", buffer,
+    ], {
+      input: text,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "ignore"],
+    })
+    return out.trimEnd().endsWith(EXACT_ACTION_OK)
+  } catch {
     return false
   }
 }
@@ -1006,6 +979,32 @@ export function sendKeys(slug: string, text: string): void {
 // pane before using these; unlike sendKeys, these never guess that a literal string is a user prompt.
 export function sendLiteral(slug: string, text: string): void {
   tmux("send-keys", "-t", tmuxSessionName(slug), "-l", text)
+}
+
+export function sendTextWithKey(slug: string, text: string, key: "Enter" | "Tab"): boolean {
+  const name = tmuxSessionName(slug)
+  const buffer = `fray-input-${randomUUID()}`
+  try {
+    const out = execFileSync("tmux", [
+      "-L", socket,
+      "load-buffer", "-b", buffer, "-",
+      ";",
+      "paste-buffer", "-b", buffer, "-t", name,
+      ";",
+      "send-keys", "-t", name, key,
+      ";",
+      "display-message", "-p", EXACT_ACTION_OK,
+      ";",
+      "delete-buffer", "-b", buffer,
+    ], {
+      input: text,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "ignore"],
+    })
+    return out.trimEnd().endsWith(EXACT_ACTION_OK)
+  } catch {
+    return false
+  }
 }
 
 export function sendKey(slug: string, key: "Enter" | "Tab" | "Up" | "Down" | "Escape"): void {

--- a/ui/packages/server/src/tmux.ts
+++ b/ui/packages/server/src/tmux.ts
@@ -427,6 +427,37 @@ export function capturePaneEscaped(slug: string): string {
   }
 }
 
+const CURSOR_CAPTURE_PREFIX = "FRAY_CURSOR_Y_9A74D2:"
+
+export interface PaneTextCapture {
+  text: string
+  cursorY: number
+}
+
+function parseCursorCapture(out: string, prefix = CURSOR_CAPTURE_PREFIX): PaneTextCapture | null {
+  const newline = out.indexOf("\n")
+  if (newline < 0 || !out.startsWith(prefix)) return null
+  const cursorY = Number(out.slice(prefix.length, newline))
+  return Number.isInteger(cursorY) && cursorY >= 0
+    ? { text: out.slice(newline + 1), cursorY }
+    : null
+}
+
+// Capture the visible escaped pane and cursor row in one tmux command queue. Codex's composer text
+// and footer are visually identical in some releases; the cursor row is the out-of-band boundary
+// that lets the input controller retain intentional blank-line-separated draft paragraphs.
+export function capturePaneEscapedWithCursor(slug: string): PaneTextCapture | null {
+  const name = tmuxSessionName(slug)
+  try {
+    return parseCursorCapture(tmux(
+      "display-message", "-p", "-t", name, `${CURSOR_CAPTURE_PREFIX}#{cursor_y}`,
+      ";", "capture-pane", "-p", "-e", "-t", name,
+    ))
+  } catch {
+    return null
+  }
+}
+
 export interface PaneIdentity {
   paneId: string
   panePid: number
@@ -529,6 +560,10 @@ export type ExactPaneCapture =
   | { kind: "captured"; text: string }
   | { kind: "unavailable" }
 
+export type ExactPaneCursorCapture =
+  | ({ kind: "captured" } & PaneTextCapture)
+  | { kind: "unavailable" }
+
 // Check token + full tuple and capture in one tmux server command. A pane replacement cannot slip
 // between authorization and capture, and a renamed exact owner remains addressable by pane id.
 export function captureExpectedAdoptionPane(
@@ -547,6 +582,27 @@ export function captureExpectedAdoptionPane(
     return out.startsWith(prefix)
       ? { kind: "captured", text: out.slice(prefix.length) }
       : { kind: "unavailable" }
+  } catch {
+    return { kind: "unavailable" }
+  }
+}
+
+// The token + immutable pane tuple and the cursor-aware capture are evaluated by one tmux server
+// command. A renamed adopted worker therefore gets the same composer boundary proof as a local one.
+export function captureExpectedAdoptionPaneWithCursor(
+  expected: ExpectedAdoptionPane,
+): ExactPaneCursorCapture {
+  const condition = expectedAdoptionCondition(expected)
+  if (!condition || expected.pane_id === null) return { kind: "unavailable" }
+  try {
+    const header = `${EXACT_ACTION_OK}:${CURSOR_CAPTURE_PREFIX}`
+    const out = tmux(
+      "if-shell", "-t", expected.pane_id, "-F", condition,
+      `display-message -p '${header}#{cursor_y}' ; capture-pane -p -e -t ${expected.pane_id}`,
+      `display-message -p ${EXACT_ACTION_MISS}`,
+    )
+    const captured = parseCursorCapture(out, header)
+    return captured ? { kind: "captured", ...captured } : { kind: "unavailable" }
   } catch {
     return { kind: "unavailable" }
   }

--- a/ui/packages/server/src/tmux.ts
+++ b/ui/packages/server/src/tmux.ts
@@ -507,8 +507,55 @@ function expectedAdoptionCondition(expected: ExpectedAdoptionPane, requireLive =
   return requireLive ? `#{&&:#{==:#{pane_dead},0},${owner}}` : owner
 }
 
+function expectedPaneIdentityCondition(expected: PaneIdentity, requireLive = true): string | null {
+  if (!/^%\d+$/.test(expected.paneId) ||
+      !Number.isSafeInteger(expected.panePid) ||
+      !Number.isSafeInteger(expected.sessionCreated)) return null
+  const owner = `#{&&:#{==:#{pane_id},${expected.paneId}},#{&&:#{==:#{pane_pid},${expected.panePid}},#{==:#{session_created},${expected.sessionCreated}}}}`
+  return requireLive ? `#{&&:#{==:#{pane_dead},0},${owner}}` : owner
+}
+
 const EXACT_ACTION_OK = "FRAY_EXACT_ACTION_OK_9A74D2"
 const EXACT_ACTION_MISS = "FRAY_EXACT_ACTION_MISS_9A74D2"
+const INPUT_SETTLE_COMMAND = "/bin/sleep 0.25"
+
+// Codex can read a pasted block and an immediately adjacent key as one input burst, leaving the
+// text in its composer even though tmux accepted both commands. A blocking run-shell remains part
+// of this one tmux server queue but gives the TUI one event-loop boundary to finish the paste. The
+// immutable pane condition is checked before the paste and again before the delayed key, so a pane
+// replacement during that boundary cannot receive either half under a reused name/id.
+function sendTextWithKeyToPane(
+  socketName: string,
+  paneId: string,
+  condition: string,
+  bufferPrefix: string,
+  text: string,
+  key: "Enter" | "Tab",
+): boolean {
+  const buffer = `${bufferPrefix}-${randomUUID()}`
+  const complete = `send-keys -t ${paneId} ${key} ; display-message -p ${EXACT_ACTION_OK}`
+  const afterSettle = `if-shell -t ${paneId} -F '${condition}' '${complete}' 'display-message -p ${EXACT_ACTION_MISS}'`
+  const authorized = `paste-buffer -b ${buffer} -t ${paneId} ; run-shell '${INPUT_SETTLE_COMMAND}' ; ${afterSettle}`
+  try {
+    const out = execFileSync("tmux", [
+      "-L", socketName,
+      "load-buffer", "-b", buffer, "-",
+      ";",
+      "if-shell", "-t", paneId, "-F", condition,
+      authorized,
+      `display-message -p ${EXACT_ACTION_MISS}`,
+      ";",
+      "delete-buffer", "-b", buffer,
+    ], {
+      input: text,
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "ignore"],
+    })
+    return out.trimEnd().endsWith(EXACT_ACTION_OK)
+  } catch {
+    return false
+  }
+}
 
 function exactPaneAction(expected: ExpectedAdoptionPane, command: string, onMiss = ""): boolean {
   const condition = expectedAdoptionCondition(expected)
@@ -593,26 +640,7 @@ export function sendTextWithKeyToExpectedAdoptionPane(
 ): boolean {
   const condition = expectedAdoptionCondition(expected)
   if (!condition || expected.pane_id === null) return false
-  const buffer = `fray-exact-${randomUUID()}`
-  try {
-    const out = execFileSync("tmux", [
-      "-L", socket,
-      "load-buffer", "-b", buffer, "-",
-      ";",
-      "if-shell", "-t", expected.pane_id, "-F", condition,
-      `paste-buffer -b ${buffer} -t ${expected.pane_id} ; send-keys -t ${expected.pane_id} ${key} ; display-message -p ${EXACT_ACTION_OK}`,
-      `display-message -p ${EXACT_ACTION_MISS}`,
-      ";",
-      "delete-buffer", "-b", buffer,
-    ], {
-      input: text,
-      encoding: "utf8",
-      stdio: ["pipe", "pipe", "ignore"],
-    })
-    return out.trimEnd().endsWith(EXACT_ACTION_OK)
-  } catch {
-    return false
-  }
+  return sendTextWithKeyToPane(socket, expected.pane_id, condition, "fray-exact", text, key)
 }
 
 export function sendKeyToExpectedAdoptionPane(
@@ -982,29 +1010,11 @@ export function sendLiteral(slug: string, text: string): void {
 }
 
 export function sendTextWithKey(slug: string, text: string, key: "Enter" | "Tab"): boolean {
-  const name = tmuxSessionName(slug)
-  const buffer = `fray-input-${randomUUID()}`
-  try {
-    const out = execFileSync("tmux", [
-      "-L", socket,
-      "load-buffer", "-b", buffer, "-",
-      ";",
-      "paste-buffer", "-b", buffer, "-t", name,
-      ";",
-      "send-keys", "-t", name, key,
-      ";",
-      "display-message", "-p", EXACT_ACTION_OK,
-      ";",
-      "delete-buffer", "-b", buffer,
-    ], {
-      input: text,
-      encoding: "utf8",
-      stdio: ["pipe", "pipe", "ignore"],
-    })
-    return out.trimEnd().endsWith(EXACT_ACTION_OK)
-  } catch {
-    return false
-  }
+  const identity = paneIdentity(slug)
+  if (!identity) return false
+  const condition = expectedPaneIdentityCondition(identity)
+  if (!condition) return false
+  return sendTextWithKeyToPane(socket, identity.paneId, condition, "fray-input", text, key)
 }
 
 export function sendKey(slug: string, key: "Enter" | "Tab" | "Up" | "Down" | "Escape"): void {

--- a/ui/packages/web/src/lib/transcript-sync.test.ts
+++ b/ui/packages/web/src/lib/transcript-sync.test.ts
@@ -2,31 +2,124 @@ import { test } from "node:test"
 import assert from "node:assert/strict"
 import { mergeOptimistic, isTranscriptStale, newestRenderedAt, type QueuedMessage } from "./transcript-sync.ts"
 
-const user = (text: string, opts: { queued?: boolean; at?: string } = {}): QueuedMessage => ({
+const user = (text: string, opts: { queued?: boolean; at?: string; sourceId?: string } = {}): QueuedMessage => ({
   role: "user",
   text,
   tools: [],
   parts: [],
   ...(opts.queued ? { queued: true } : {}),
   ...(opts.at ? { at: opts.at } : {}),
+  ...(opts.sourceId ? { sourceId: opts.sourceId } : {}),
 })
 
 // ---- mergeOptimistic (S1: preserve unconsumed optimistic sends across a cache overwrite) ----
 test("mergeOptimistic: an optimistic bubble not yet in server truth is preserved (re-appended)", () => {
-  const out = mergeOptimistic([user("old"), user("pending send", { queued: true })], [user("old")])
+  const old = user("old", { sourceId: "old-turn" })
+  const out = mergeOptimistic([old, user("pending send", { queued: true })], [old])
   assert.equal(out.length, 2)
   assert.equal(out[1].text, "pending send")
 })
 
 test("mergeOptimistic: an optimistic bubble now present in server truth is dropped (no duplicate)", () => {
-  const out = mergeOptimistic([user("old"), user("landed", { queued: true })], [user("old"), user("landed")])
+  const old = user("old", { sourceId: "old-turn" })
+  const out = mergeOptimistic(
+    [old, user("landed", { queued: true })],
+    [old, user("landed", { sourceId: "landed-turn" })],
+  )
   assert.equal(out.length, 2)
   assert.equal(out.filter((m) => m.text === "landed").length, 1)
 })
 
 test("mergeOptimistic: the server's OWN queued copy also consumes the optimistic bubble", () => {
-  const out = mergeOptimistic([user("landed", { queued: true })], [user("landed", { queued: true })])
+  const out = mergeOptimistic(
+    [user("landed", { queued: true })],
+    [user("landed", { queued: true, sourceId: "server-queued-turn" })],
+  )
   assert.equal(out.length, 1)
+})
+
+test("mergeOptimistic: an unchanged server queued copy is not appended beside itself", () => {
+  const serverQueued = user("landed", { queued: true, sourceId: "server-queued-turn" })
+  const incoming = [serverQueued]
+  assert.equal(mergeOptimistic([serverQueued], incoming), incoming)
+})
+
+test("mergeOptimistic: one landed turn consumes consecutive optimistic messages it coalesces", () => {
+  const first = '"Add inter-thread spawning and internal linking"'
+  const second = "The agent received both messages, but they still look enqueued."
+  const landed = `${first}\n\n${second}`
+  const out = mergeOptimistic(
+    [user("old", { sourceId: "old-turn" }), user(first, { queued: true }), user(second, { queued: true })],
+    [user("old", { sourceId: "old-turn" }), user(landed, { sourceId: "landed-turn" })],
+  )
+  assert.deepEqual(out.map((message) => message.text), ["old", landed])
+})
+
+test("mergeOptimistic: a historical coalesced turn is not fresh delivery evidence", () => {
+  const first = "repeat first"
+  const second = "repeat second"
+  const landed = `${first}\n\n${second}`
+  const old = user(landed, { sourceId: "old-turn" })
+  const out = mergeOptimistic(
+    [old, user(first, { queued: true }), user(second, { queued: true })],
+    [old],
+  )
+  assert.deepEqual(out.map((message) => message.text), [landed, first, second])
+})
+
+test("mergeOptimistic: a repeated coalesced turn with a new source id consumes the new sends", () => {
+  const first = "repeat first"
+  const second = "repeat second"
+  const landed = `${first}\n\n${second}`
+  const old = user(landed, { sourceId: "old-turn" })
+  const fresh = user(landed, { sourceId: "new-turn" })
+  const out = mergeOptimistic(
+    [old, user(first, { queued: true }), user(second, { queued: true })],
+    [old, fresh],
+  )
+  assert.deepEqual(out, [old, fresh])
+})
+
+test("mergeOptimistic: one coalesced turn consumes only the first of two repeated queued runs", () => {
+  const landed = user("a\n\nb", { sourceId: "landed-turn" })
+  const out = mergeOptimistic(
+    [user("a", { queued: true }), user("b", { queued: true }), user("a", { queued: true }), user("b", { queued: true })],
+    [landed],
+  )
+  assert.deepEqual(out.map((message) => message.text), [landed.text, "a", "b"])
+})
+
+test("mergeOptimistic: two fresh coalesced turns consume two repeated queued runs", () => {
+  const first = user("a\n\nb", { sourceId: "landed-turn-1" })
+  const second = user("a\n\nb", { sourceId: "landed-turn-2" })
+  const out = mergeOptimistic(
+    [user("a", { queued: true }), user("b", { queued: true }), user("a", { queued: true }), user("b", { queued: true })],
+    [first, second],
+  )
+  assert.deepEqual(out, [first, second])
+})
+
+test("mergeOptimistic: one overlapping coalesced turn cannot consume the same evidence twice", () => {
+  const landed = user("a\n\na", { sourceId: "landed-turn" })
+  const out = mergeOptimistic(
+    [user("a", { queued: true }), user("a", { queued: true }), user("a", { queued: true })],
+    [landed],
+  )
+  assert.deepEqual(out.map((message) => message.text), [landed.text, "a"])
+})
+
+test("mergeOptimistic: a single optimistic paragraph is not consumed by incidental landed prose", () => {
+  const pending = user("shared paragraph", { queued: true })
+  const landed = user("An unrelated introduction.\n\nshared paragraph", { sourceId: "landed-turn" })
+  const out = mergeOptimistic([pending], [landed])
+  assert.deepEqual(out.map((message) => message.text), [landed.text, pending.text])
+})
+
+test("mergeOptimistic: id-less input is not accepted as fresh delivery evidence", () => {
+  const pending = user("landed", { queued: true })
+  const out = mergeOptimistic([pending], [user("landed")])
+  assert.deepEqual(out.map((message) => message.text), ["landed", "landed"])
+  assert.equal(out[1].queued, true)
 })
 
 test("mergeOptimistic: no optimistic entries → returns the incoming array unchanged (identity)", () => {

--- a/ui/packages/web/src/lib/transcript-sync.ts
+++ b/ui/packages/web/src/lib/transcript-sync.ts
@@ -3,21 +3,67 @@ import type { TranscriptMessage } from "@fray-ui/shared"
 // A transcript message that may carry the client-only/queued flag (server pending OR local optimistic).
 export type QueuedMessage = TranscriptMessage & { queued?: boolean }
 
+function freshServerUserTexts(prev: QueuedMessage[], incoming: QueuedMessage[]): string[] {
+  const previousSourceIds = new Set(
+    prev.filter((m) => m.role === "user" && m.sourceId).map((m) => m.sourceId),
+  )
+  return incoming
+    .filter((message) => message.role === "user" && message.sourceId && !previousSourceIds.has(message.sourceId))
+    .map((message) => message.text.trim())
+}
+
+function consumedOptimisticIndexes(optimistic: QueuedMessage[], serverUserTexts: string[]): Set<number> {
+  const consumed = new Set<number>()
+  const separator = "\n\n"
+
+  for (const serverText of serverUserTexts) {
+    for (let start = 0; start < optimistic.length; start++) {
+      if (consumed.has(start)) continue
+      const first = optimistic[start].text.trim()
+      if (serverText === first) {
+        consumed.add(start)
+        break
+      }
+      if (!serverText.startsWith(first)) continue
+      let offset = first.length
+      for (let end = start + 1; end < optimistic.length; end++) {
+        if (consumed.has(end)) break
+        const next = optimistic[end].text.trim()
+        if (!serverText.startsWith(separator, offset) || !serverText.startsWith(next, offset + separator.length)) break
+        offset += separator.length + next.length
+        if (offset !== serverText.length) continue
+        for (let i = start; i <= end; i++) consumed.add(i)
+        break
+      }
+      if (consumed.has(start)) break
+    }
+  }
+  return consumed
+}
+
 // ── Layer 3: optimistic-merge hardening (the sync audit's S1 finding) ──────────────────────────────────
 // A transcript cache OVERWRITE (a poll refetch OR a socket push) must not blunt-replace an optimistic
 // "queued" bubble the client appended on send but the incoming server truth doesn't yet carry — that
 // blunt replace is exactly what makes a just-sent message VANISH for the window before the server's own
 // copy (a pending/delivered queued message — see the server parser) shows up. So: re-append any optimistic
-// queued user entry whose text isn't present in the incoming server user messages; drop the ones the
-// server has now materialized (matched by trimmed text) so there's never a duplicate. With the server
-// now carrying the message within ~a tick this is a short bridge, but it closes the visible swallow.
+// queued user entry until a newly observed server user record accounts for it; drop the ones the server
+// has now materialized so there's never a duplicate. With the server now carrying the message within
+// ~a tick this is a short bridge, but it closes the visible swallow.
 export function mergeOptimistic(prev: QueuedMessage[] | undefined, incoming: QueuedMessage[]): QueuedMessage[] {
   if (!prev?.length) return incoming
-  const optimistic = prev.filter((m) => m.queued && m.role === "user" && m.text.trim())
+  // Server-projected pending turns also carry `queued`, but unlike client-only optimistic sends they
+  // already have a stable sourceId and must never be re-appended beside the same incoming record.
+  const optimistic = prev.filter((m) => m.queued && !m.sourceId && m.role === "user" && m.text.trim())
   if (!optimistic.length) return incoming
-  // Any incoming USER text (delivered OR the server's own queued copy) consumes a matching optimistic entry.
-  const serverUserTexts = new Set(incoming.filter((m) => m.role === "user").map((m) => m.text.trim()))
-  const unconsumed = optimistic.filter((m) => !serverUserTexts.has(m.text.trim()))
+  // A newly observed server USER record (delivered OR the server's own queued copy) consumes a matching
+  // optimistic entry. Every current transcript parser assigns a stable sourceId; id-less input is ignored
+  // rather than using text-count heuristics that can mistake historical repeated prose for fresh delivery.
+  // Codex can also materialize several consecutive sends as one user turn joined by blank lines. Consume
+  // that whole run only when at least two optimistic texts reconstruct the complete server turn; a lone
+  // matching paragraph inside unrelated prose is not delivery proof.
+  const serverUserTexts = freshServerUserTexts(prev, incoming)
+  const consumed = consumedOptimisticIndexes(optimistic, serverUserTexts)
+  const unconsumed = optimistic.filter((_, i) => !consumed.has(i))
   return unconsumed.length ? [...incoming, ...unconsumed] : incoming
 }
 


### PR DESCRIPTION
## Summary

- reconcile consecutive client-only queued messages when Codex materializes them as one blank-line-joined user turn
- require a newly observed stable server `sourceId`, and consume each fresh server turn at most once
- preserve repeated and overlapping queued runs until distinct server evidence accounts for each one
- atomically paste and submit new Codex follow-ups only from a verified empty or exactly matching composer, after persisting the durable submission barrier
- wait for Codex to process the paste, then reauthorize the immutable pane before sending the key; never replay an indeterminate submission
- steer current active Codex turns with `Enter` (Codex's immediate-send control), rather than `Tab` (Codex's deferred queue control)
- accept current Codex's verified composer plus authoritative `turn: in-flight` telemetry when the old `tab to queue message` footer is absent
- fail closed behind native permissions, questions, or tool modals, including the stale/dim composer Codex can leave visible beneath an overlay
- continue recognizing older `Queued follow-up inputs` ownership so existing provider-side queues drain safely during upgrades
- repair the CI monitor assertion left pointing at deleted worker-prompt source files

## Verification

- `nub run test` — 1,527 passed, 9 skipped
- `nub run --filter @fray-ui/web build` — passed
- `./node_modules/.bin/tsc -b packages/shared packages/rpc packages/server` — passed
- focused interaction/controller/socket coverage — 64 passed
- `node --test monitors/github-watch.test.mjs monitors/portable-monitors.test.mjs` plus generated-monitor sync check — 16 passed
- standalone replacement-during-settle race — passed after one host-loaded full-suite run missed the test's observation window; uncontended full suite then passed
- real Chromium → RPC → tmux → Codex active steer at 1440×1000 and 430×900: input reached Codex at `20:26:51.264Z`, was acknowledged at `20:26:52.999Z`, and the active tool completed later at `20:27:10.986Z`
- the real run cleared `codex_input_queue`, `runtime_control`, and `control_error`; every `/rpc/followUp` returned 200, console/page errors were empty, and both widths had no horizontal overflow
- independent adversarial review's modal-overlay finding was fixed and covered by the exact captured layout

## Upstream gate state

- `nub run typecheck` remains red only on current `origin/main` errors in untouched `GithubPickerModal.tsx` and `githubDispatch.ts`
