### PR TITLE
Make provider command copy feedback immediate

### DIFF
--- a/monitors/portable-monitors.test.mjs
+++ b/monitors/portable-monitors.test.mjs
@@ -37,8 +37,9 @@ test("Codex and Claude provider guidance prefer declared tooling and make no Lun
   assert.doesNotMatch(codex, /exactly one `gpt-5\.6-luna` \+ `medium` monitor child/)
   assert.match(claude, /use native `Monitor`/)
 
-  const codexPrompt = readFileSync(join(root, "ui/WORKER_PROMPT.codex.md"), "utf8")
-  const claudePrompt = readFileSync(join(root, "ui/WORKER_PROMPT.claude.md"), "utf8")
+  const promptDir = join(root, "ui/packages/server/src")
+  const codexPrompt = readFileSync(join(promptDir, "WORKER_PROMPT.codex.golden.txt"), "utf8")
+  const claudePrompt = readFileSync(join(promptDir, "WORKER_PROMPT.claude.golden.txt"), "utf8")
   for (const prompt of [codexPrompt, claudePrompt]) {
     assert.match(prompt, /project-local `AGENTS\.md`/)
     assert.match(prompt, /terminal event\/exit semantics/)

--- a/ui/packages/server/src/router.test.ts
+++ b/ui/packages/server/src/router.test.ts
@@ -201,10 +201,13 @@ test("threadTerminalCommand offers the verified provider resume command in every
 
     const expected = { command: `cd '${h.dir}' && codex resume 'codex-rollout-id'`, mode: "resume", reason: null }
 
+    h.board.snapshot = async () => {
+      throw new Error("the copy path must not rebuild the board")
+    }
     assert.deepEqual(
       await h.router.threadTerminalCommand.handler({ input: { slug: "codex-resume" } }),
       expected,
-      "Codex resumes its provider rollout ID rather than Fray's local owner UUID",
+      "Codex resumes its provider rollout ID directly from the owned registry row",
     )
 
     // Resuming a live session in another terminal is safe + supported, so the command is offered while

--- a/ui/packages/server/src/router.ts
+++ b/ui/packages/server/src/router.ts
@@ -736,19 +736,17 @@ export function createRouter(ctx: AppContext) {
       },
     }),
 
-    // Copy only a provider-native resume invocation. The board snapshot is the ownership authority:
-    // a row in SQLite alone is insufficient if it is no longer an owned session view. The command is a
-    // provider-native `claude --resume`/`codex resume` that attaches a SECOND client to the same session
-    // — it never touches Fray's private tmux pane — so it is offered in every runtime state, live too
-    // (see the handler body). Do not return a command for foreign discovery, legacy docs, or an
-    // absent/replaced registry row.
+    // Copy only a provider-native resume invocation. The durable session registry is the ownership
+    // boundary: board session views are derived from these exact rows, while foreign discoveries and
+    // legacy docs have no row. Avoid rebuilding the full board on this latency-sensitive click path.
+    // The command attaches a SECOND provider client and never touches Fray's private tmux pane, so it
+    // is offered in every runtime state, live too. An absent/replaced row fails closed.
     threadTerminalCommand: query({
       input: SlugInput,
       output: z.object({ command: z.string().nullable(), mode: z.enum(["resume", "unavailable"]), reason: z.string().nullable() }),
       handler: async ({ input }) => {
         const row = ctx.storage.getSession(input.slug)
-        const thread = (await ctx.board.snapshot()).threads.find((candidate) => candidate.id === input.slug)
-        if (!row || !thread || thread.kind !== "session" || thread.foreign) {
+        if (!row) {
           throw new Error("No Fray-owned terminal session is available for this thread")
         }
         // Resuming the SAME session from another terminal is safe and supported by both CLIs whether or

--- a/ui/packages/web/src/components/ChatView.tsx
+++ b/ui/packages/web/src/components/ChatView.tsx
@@ -2089,7 +2089,7 @@ export function PermPromptBanner({ onTerminal }: { onTerminal: () => void }) {
         The agent is waiting on a <span className="font-medium">permission approval</span> — respond in your external terminal.
       </span>
       <button
-        onClick={onTerminal}
+        onClick={() => onTerminal()}
         onMouseDown={(e) => e.preventDefault()}
         className="shrink-0 rounded-md border border-border px-2 py-1 text-[11px] text-fg/90 transition-colors hover:bg-panel hover:border-border-strong"
       >
@@ -2123,7 +2123,7 @@ export function NativeInputRequiredCard({ input, onTerminal }: { input: NativeIn
       </div>
       <div className="mt-3 flex justify-end">
         <button
-          onClick={onTerminal}
+          onClick={() => onTerminal()}
           onMouseDown={(e) => e.preventDefault()}
           className="rounded-md border border-accent/50 bg-panel px-2.5 py-1.5 text-[11px] font-medium text-fg transition-colors hover:border-accent hover:bg-panel-2"
         >
@@ -2255,7 +2255,7 @@ export function PendingAskCard({ ask, onTerminal }: { ask: PendingAsk; onTermina
         ))}
       </div>
       <button
-        onClick={onTerminal}
+        onClick={() => onTerminal()}
         onMouseDown={(e) => e.preventDefault()}
         className="mt-3 flex items-center gap-1.5 rounded-md bg-fg px-3 py-1.5 text-[12px] font-medium text-bg outline-none transition-all hover:opacity-90 active:scale-95"
       >

--- a/ui/packages/web/src/components/ExternalTerminalCommand.test.ts
+++ b/ui/packages/web/src/components/ExternalTerminalCommand.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import test from "node:test"
+import { fileURLToPath } from "node:url"
+
+const source = readFileSync(fileURLToPath(new URL("./ExternalTerminalCommand.tsx", import.meta.url)), "utf8")
+
+test("copy command button wires the feedback lifecycle before starting the copy and renders both icon states", () => {
+  assert.match(source, /function handleCopy\(\) \{\s*const generation = feedback\.current!\.begin\(\)\s*copy\(\{ onError:/)
+  assert.match(source, /copied\s*\? <Check[\s\S]*: <TerminalSquare/)
+  assert.match(source, /useEffect\(\(\) => \(\) => feedback\.current\?\.dispose\(\), \[\]\)/)
+  assert.match(source, /const label = copied \? "Provider resume command copied" : "Copy provider resume command"/)
+})

--- a/ui/packages/web/src/components/ExternalTerminalCommand.tsx
+++ b/ui/packages/web/src/components/ExternalTerminalCommand.tsx
@@ -1,6 +1,8 @@
 import { useMutation } from "@tanstack/react-query"
-import { TerminalSquare } from "lucide-react"
+import { Check, TerminalSquare } from "lucide-react"
+import { useEffect, useRef, useState } from "react"
 import { rpc } from "../api/rpc.ts"
+import { createCopyCommandFeedback } from "../lib/copyCommandFeedback.ts"
 import { showToast } from "../store.ts"
 import { Tooltip } from "./Tooltip.tsx"
 
@@ -9,7 +11,11 @@ async function copyText(value: string): Promise<void> {
   await navigator.clipboard.writeText(value)
 }
 
-export function useCopyTerminalCommand(slug: string): () => void {
+interface CopyCallbacks {
+  onError?: () => void
+}
+
+export function useCopyTerminalCommand(slug: string): (callbacks?: CopyCallbacks) => void {
   const copy = useMutation({
     mutationFn: async () => {
       const result = await rpc.threadTerminalCommand({ slug })
@@ -18,9 +24,12 @@ export function useCopyTerminalCommand(slug: string): () => void {
       await copyText(command)
     },
   })
-  return () => copy.mutate(undefined, {
+  return (callbacks) => copy.mutate(undefined, {
     onSuccess: () => showToast("Provider resume command copied"),
-    onError: (error) => showToast(error instanceof Error ? `Could not copy provider resume command: ${error.message}` : "Could not copy provider resume command", { duration: 7000 }),
+    onError: (error) => {
+      callbacks?.onError?.()
+      showToast(error instanceof Error ? `Could not copy provider resume command: ${error.message}` : "Could not copy provider resume command", { duration: 7000 })
+    },
   })
 }
 
@@ -29,17 +38,36 @@ export function useCopyTerminalCommand(slug: string): () => void {
 // attempts a copy; if the server genuinely has no resumable id (e.g. codex before its first turn),
 // the mutation surfaces the reason as a toast rather than pre-disabling the affordance.
 export function CopyTerminalCommandButton({ slug }: { slug: string }) {
+  const [copied, setCopied] = useState(false)
+  const feedback = useRef<ReturnType<typeof createCopyCommandFeedback> | null>(null)
+  if (!feedback.current) {
+    feedback.current = createCopyCommandFeedback(setCopied, {
+      setTimeout: (callback, delay) => window.setTimeout(callback, delay),
+      clearTimeout: (timer) => window.clearTimeout(timer),
+    })
+  }
   const copy = useCopyTerminalCommand(slug)
+
+  useEffect(() => () => feedback.current?.dispose(), [])
+
+  function handleCopy() {
+    const generation = feedback.current!.begin()
+    copy({ onError: () => feedback.current?.fail(generation) })
+  }
+
+  const label = copied ? "Provider resume command copied" : "Copy provider resume command"
   return (
-    <Tooltip label="Copy provider resume command">
+    <Tooltip label={label}>
       <button
         type="button"
-        aria-label="Copy provider resume command"
-        title="Copy provider resume command"
-        onClick={() => copy()}
+        aria-label={label}
+        title={label}
+        onClick={handleCopy}
         className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted outline-none transition-colors hover:bg-panel-2 hover:text-fg"
       >
-        <TerminalSquare size={14} strokeWidth={1.8} />
+        {copied
+          ? <Check size={14} strokeWidth={2.2} className="text-live" />
+          : <TerminalSquare size={14} strokeWidth={1.8} />}
       </button>
     </Tooltip>
   )

--- a/ui/packages/web/src/lib/copyCommandFeedback.test.ts
+++ b/ui/packages/web/src/lib/copyCommandFeedback.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { COPY_COMMAND_FEEDBACK_MS, createCopyCommandFeedback } from "./copyCommandFeedback.ts"
+
+function harness() {
+  let nextTimer = 0
+  const callbacks = new Map<number, () => void>()
+  const cleared: number[] = []
+  const states: boolean[] = []
+  const feedback = createCopyCommandFeedback(
+    (copied) => states.push(copied),
+    {
+      setTimeout: (callback, delay) => {
+        assert.equal(delay, COPY_COMMAND_FEEDBACK_MS)
+        callbacks.set(++nextTimer, callback)
+        return nextTimer
+      },
+      clearTimeout: (timer) => {
+        cleared.push(timer)
+        callbacks.delete(timer)
+      },
+    },
+  )
+  return { feedback, callbacks, cleared, states }
+}
+
+test("copy feedback acknowledges immediately, resets on schedule, and restarts on a repeated click", () => {
+  const h = harness()
+  const first = h.feedback.begin()
+  assert.deepEqual(h.states, [true])
+  assert.equal(h.callbacks.size, 1)
+
+  const second = h.feedback.begin()
+  assert.notEqual(second, first)
+  assert.deepEqual(h.states, [true, true])
+  assert.deepEqual(h.cleared, [1])
+  assert.equal(h.callbacks.has(2), true)
+
+  h.callbacks.get(2)!()
+  assert.deepEqual(h.states, [true, true, false])
+})
+
+test("only the current failed copy clears feedback, and disposal cancels the pending reset", () => {
+  const h = harness()
+  const first = h.feedback.begin()
+  const second = h.feedback.begin()
+
+  h.feedback.fail(first)
+  assert.deepEqual(h.states, [true, true])
+
+  h.feedback.fail(second)
+  assert.deepEqual(h.states, [true, true, false])
+  assert.deepEqual(h.cleared, [1, 2])
+
+  h.feedback.begin()
+  h.feedback.dispose()
+  assert.deepEqual(h.cleared, [1, 2, 3])
+  assert.equal(h.callbacks.size, 0)
+})

--- a/ui/packages/web/src/lib/copyCommandFeedback.ts
+++ b/ui/packages/web/src/lib/copyCommandFeedback.ts
@@ -1,0 +1,42 @@
+export const COPY_COMMAND_FEEDBACK_MS = 1500
+
+interface FeedbackClock {
+  setTimeout(callback: () => void, delay: number): number
+  clearTimeout(timer: number): void
+}
+
+export function createCopyCommandFeedback(
+  setCopied: (copied: boolean) => void,
+  clock: FeedbackClock,
+) {
+  let generation = 0
+  let resetTimer: number | undefined
+
+  function clearResetTimer() {
+    if (resetTimer === undefined) return
+    clock.clearTimeout(resetTimer)
+    resetTimer = undefined
+  }
+
+  return {
+    begin(): number {
+      const current = ++generation
+      setCopied(true)
+      clearResetTimer()
+      resetTimer = clock.setTimeout(() => {
+        if (current === generation) setCopied(false)
+        resetTimer = undefined
+      }, COPY_COMMAND_FEEDBACK_MS)
+      return current
+    },
+    fail(failedGeneration: number) {
+      if (failedGeneration !== generation) return
+      clearResetTimer()
+      setCopied(false)
+    },
+    dispose() {
+      generation++
+      clearResetTimer()
+    },
+  }
+}


### PR DESCRIPTION
## Summary

- acknowledge provider-command copy clicks immediately with a temporary check icon
- restore the terminal icon after 1.5 seconds, or immediately if the copy fails
- avoid rebuilding the full board before returning a command for a durable owned session
- repair the pre-existing portable-monitor CI test to read the compiled worker prompt location

## Verification

- `pnpm exec tsx --tsconfig packages/web/tsconfig.json --test packages/server/src/router.test.ts packages/web/src/components/ExternalTerminalCommand.test.ts packages/web/src/lib/copyCommandFeedback.test.ts` (35 passed)
- `pnpm test` (1514 passed, 0 failed, 9 skipped)
- `pnpm --filter @fray-ui/web build`
- `node --test monitors/*.test.mjs` (16 passed)
- real Chromium QA at desktop and narrow widths, including success, reset, tooltip, and forced clipboard failure states; console and page errors clean
- GitHub `version-check` passed on the final head

## Existing repository issue

- `pnpm typecheck` remains blocked by the pre-existing `GithubPickerModal.tsx:176` and `githubDispatch.ts:54,65` errors; this PR does not touch those files.