### PR TITLE
Add standalone virtualized thread view

### DIFF
--- a/monitors/portable-monitors.test.mjs
+++ b/monitors/portable-monitors.test.mjs
@@ -37,8 +37,8 @@ test("Codex and Claude provider guidance prefer declared tooling and make no Lun
   assert.doesNotMatch(codex, /exactly one `gpt-5\.6-luna` \+ `medium` monitor child/)
   assert.match(claude, /use native `Monitor`/)
 
-  const codexPrompt = readFileSync(join(root, "ui/WORKER_PROMPT.codex.md"), "utf8")
-  const claudePrompt = readFileSync(join(root, "ui/WORKER_PROMPT.claude.md"), "utf8")
+  const codexPrompt = readFileSync(join(root, "ui/packages/server/src/WORKER_PROMPT.codex.golden.txt"), "utf8")
+  const claudePrompt = readFileSync(join(root, "ui/packages/server/src/WORKER_PROMPT.claude.golden.txt"), "utf8")
   for (const prompt of [codexPrompt, claudePrompt]) {
     assert.match(prompt, /project-local `AGENTS\.md`/)
     assert.match(prompt, /terminal event\/exit semantics/)

--- a/ui/packages/web/package.json
+++ b/ui/packages/web/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-tabs": "^1.1.16",
     "@radix-ui/react-tooltip": "^1.2.11",
     "@tanstack/react-query": "^5",
+    "@tanstack/react-virtual": "^3.14.7",
     "@xstate/react": "^6.1.0",
     "@xterm/addon-fit": "^0.11",
     "@xterm/addon-webgl": "^0.19",

--- a/ui/packages/web/src/components/ChatView.tsx
+++ b/ui/packages/web/src/components/ChatView.tsx
@@ -3,7 +3,7 @@ import { useSnapshot } from "valtio"
 import * as RadixTabs from "@radix-ui/react-tabs"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useVirtualizer } from "@tanstack/react-virtual"
-import { AlertTriangle, ArrowDown, ArrowUpRight, Check, ChevronRight, Clock, FileText, HelpCircle, KeyRound, ListChecks, Loader2, ShieldCheck, Sparkles, X } from "lucide-react"
+import { AlertTriangle, ArrowDown, ArrowLeft, ArrowUpRight, Check, ChevronRight, Clock, FileText, HelpCircle, KeyRound, ListChecks, Loader2, ShieldCheck, Sparkles, X } from "lucide-react"
 import type { AwaitingHint, NativeInputRequired as NativeInputRequiredData, PendingAsk, ThreadView as ThreadViewData, TranscriptEdit, TranscriptMessage, TranscriptToolCall } from "@fray-ui/shared"
 import { isValidAwaitingTimer } from "@fray-ui/shared"
 import { store, threadBySlug, pushDrawer, pushSubAgentDrawer, showToast } from "../store.ts"
@@ -70,7 +70,7 @@ export const ThreadSlugContext = createContext<string | null>(null)
 // scratchpad doc (a session thread's compaction-proof working memory — read-only).
 export type ThreadTab = "chat" | "scratch"
 
-export function ThreadView({ slug, tab, onTab, onStatusApplied, onClose, virtualized = false }: { slug: string; tab: ThreadTab; onTab: (t: ThreadTab) => void; onStatusApplied?: () => void; onClose?: () => void; virtualized?: boolean }) {
+export function ThreadView({ slug, tab, onTab, onStatusApplied, onClose, virtualized = false, showReturnToQueue = false }: { slug: string; tab: ThreadTab; onTab: (t: ThreadTab) => void; onStatusApplied?: () => void; onClose?: () => void; virtualized?: boolean; showReturnToQueue?: boolean }) {
   const board = useBoard()
   const thread = threadBySlug(board, slug)
   return (
@@ -80,7 +80,7 @@ export function ThreadView({ slug, tab, onTab, onStatusApplied, onClose, virtual
       activationMode="automatic"
       className="flex-1 min-h-0 flex flex-col"
     >
-      <ThreadHeader slug={slug} tab={tab} onStatusApplied={onStatusApplied} onClose={onClose} />
+      <ThreadHeader slug={slug} tab={tab} onStatusApplied={onStatusApplied} onClose={onClose} showReturnToQueue={showReturnToQueue} />
       {tab === "scratch" ? (
         <RadixTabs.Content value="scratch" className="flex-1 min-h-0 flex flex-col outline-none">
         <InteractionStack
@@ -193,7 +193,16 @@ function ChatView({ slug, onTab, virtualized }: { slug: string; onTab: (t: Threa
       data-drawer-scroll-ready={q.isPending ? "false" : "true"}
       className="flex-1 min-h-0 flex flex-col overflow-hidden outline-none"
     >
-      <div ref={transcriptRef} data-drawer-transcript-scroll data-standalone-transcript={virtualized || undefined} className="relative min-h-0 flex-1 overflow-y-auto">
+      <div
+        ref={transcriptRef}
+        data-drawer-transcript-scroll
+        data-standalone-transcript={virtualized || undefined}
+        tabIndex={virtualized ? 0 : undefined}
+        role={virtualized ? "region" : undefined}
+        aria-label={virtualized ? "Thread conversation" : undefined}
+        aria-busy={virtualized && loadingEarlier ? true : undefined}
+        className="relative min-h-0 flex-1 overflow-y-auto outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-fg/60"
+      >
       {virtualized && count > 0 ? (
         <VirtualizedThreadTranscript
           slug={slug}
@@ -664,7 +673,9 @@ function VirtualizedThreadTranscript({
                 ) : loadingEarlier ? (
                   <span className="flex items-center gap-2"><Loader2 size={12} className="animate-spin" /> Loading earlier messages…</span>
                 ) : (
-                  <span>Scroll up to load earlier messages</span>
+                  <button type="button" onClick={requestEarlier} className="rounded-md px-2 py-1 outline-none hover:bg-panel-2 hover:text-fg focus-visible:ring-1 focus-visible:ring-fg/60">
+                    Load earlier messages
+                  </button>
                 )}
               </div>
             ) : row.kind === "message" ? (
@@ -718,7 +729,7 @@ function VirtualizedThreadTranscript({
 // non-lifecycle HeaderActions. Snooze and Archive stay in the persistent thread footer. The tab is CONTROLLED
 // (tab/onTab) so the drawer drives its own copy. Owned sessions expose a command-copy icon; foreign
 // rows do not. The Doc tab appears only when the thread has a provisioned scratchpad.
-export function ThreadHeader({ slug, tab, onStatusApplied, onClose }: { slug: string; tab: ThreadTab; onStatusApplied?: () => void; onClose?: () => void }) {
+export function ThreadHeader({ slug, tab, onStatusApplied, onClose, showReturnToQueue = false }: { slug: string; tab: ThreadTab; onStatusApplied?: () => void; onClose?: () => void; showReturnToQueue?: boolean }) {
   const board = useBoard()
   const thread = threadBySlug(board, slug)
   const markComplete = useMutation({ mutationFn: () => rpc.markComplete({ slug }) })
@@ -796,7 +807,20 @@ export function ThreadHeader({ slug, tab, onStatusApplied, onClose }: { slug: st
       className={THREAD_HEADER_CLASS}
     >
       <div className={THREAD_HEADER_TITLE_CLASS}>
-        <div className="min-w-0 leading-tight">
+        <div className="flex min-w-0 items-center gap-1.5">
+          {showReturnToQueue && (
+            <Tooltip label="Return to queue">
+              <a
+                href="/"
+                aria-label="Return to queue"
+                data-standalone-return
+                className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted outline-none transition-colors hover:bg-panel-2 hover:text-fg focus-visible:ring-1 focus-visible:ring-fg/60"
+              >
+                <ArrowLeft size={14} />
+              </a>
+            </Tooltip>
+          )}
+          <div className="min-w-0 flex-1 leading-tight">
           {/* Keep the title's display wrapper content-sized. Long names still truncate inside the
               remaining header width, but short names do not claim the whole row as a click target. */}
           <div className="flex min-w-0 items-center gap-1">
@@ -863,6 +887,7 @@ export function ThreadHeader({ slug, tab, onStatusApplied, onClose }: { slug: st
             )}
           </div>
           <LastActive at={lastActiveLabelAt(thread)} fallbackAt={thread.spawnedAt} className="mt-0.5 block truncate text-[11px] leading-tight text-muted/75" />
+          </div>
         </div>
       </div>
       {/* At constrained drawer widths, controls get their own deliberate row. This keeps the

--- a/ui/packages/web/src/components/ChatView.tsx
+++ b/ui/packages/web/src/components/ChatView.tsx
@@ -1,12 +1,13 @@
 import { createContext, memo, useCallback, useContext, useEffect, useId, useLayoutEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react"
 import { useSnapshot } from "valtio"
 import * as RadixTabs from "@radix-ui/react-tabs"
-import { useMutation, useQuery } from "@tanstack/react-query"
-import { AlertTriangle, ArrowUpRight, Check, ChevronRight, Clock, FileText, HelpCircle, KeyRound, ListChecks, Loader2, ShieldCheck, Sparkles, X } from "lucide-react"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useVirtualizer } from "@tanstack/react-virtual"
+import { AlertTriangle, ArrowDown, ArrowUpRight, Check, ChevronRight, Clock, FileText, HelpCircle, KeyRound, ListChecks, Loader2, ShieldCheck, Sparkles, X } from "lucide-react"
 import type { AwaitingHint, NativeInputRequired as NativeInputRequiredData, PendingAsk, ThreadView as ThreadViewData, TranscriptEdit, TranscriptMessage, TranscriptToolCall } from "@fray-ui/shared"
 import { isValidAwaitingTimer } from "@fray-ui/shared"
 import { store, threadBySlug, pushDrawer, pushSubAgentDrawer, showToast } from "../store.ts"
-import { useBoard, useTranscript, useSocketTranscripts, type ChatMessage } from "../hooks.ts"
+import { useBoard, useTranscript, useSocketTranscripts, type ChatMessage, type TranscriptData } from "../hooks.ts"
 import { rpc } from "../api/rpc.ts"
 import { displayTitle, lastActiveLabelAt } from "../groups.ts"
 import { mdToHtml, mdInlineToHtml, stripFrontmatter } from "../lib/markdown.ts"
@@ -15,7 +16,7 @@ import { DiffBlock, PathLink } from "./DiffBlock.tsx"
 import { splitQuestionBlocks, parseQuestionBlock, type QuestionKind, type BlockAnswer, type MessageAnswering } from "../lib/questionBlocks.ts"
 import { splitFenceBlocks, type FenceKind } from "../lib/fenceBlocks.ts"
 import { parseAnswersMessage, pairAllAnswers, type PairedAnswer } from "../lib/answersMessage.ts"
-import { useLiveAnswering } from "../lib/answering.ts"
+import { useLiveAnswering, type LiveAnswering } from "../lib/answering.ts"
 import { useLocalFileCodeLinks } from "../lib/localFileCode.ts"
 import { shouldSubmitComposerEnter } from "../lib/composerKeyboard.ts"
 import { messagePresentationText } from "../lib/messagePresentation.ts"
@@ -38,6 +39,9 @@ import { LastActive } from "./LastActive.tsx"
 import { CopyTerminalCommandButton, useCopyTerminalCommand } from "./ExternalTerminalCommand.tsx"
 import { SignInModal } from "./SignInModal.tsx"
 import { PROVIDER_LABEL } from "../lib/signIn.ts"
+import { standaloneThreadHref } from "../lib/standaloneThreadRoute.ts"
+import { prependEarlierPage } from "../lib/transcriptPagination.ts"
+import { buildVirtualTranscriptMessageRows, earlierLoadGate, type VirtualTranscriptMessageRow } from "../lib/virtualTranscript.ts"
 
 // Answer types moved to lib/questionBlocks.ts (shared by the queue card, the thread view, and the
 // answering controller). Re-exported here so existing importers keep working.
@@ -66,7 +70,7 @@ export const ThreadSlugContext = createContext<string | null>(null)
 // scratchpad doc (a session thread's compaction-proof working memory — read-only).
 export type ThreadTab = "chat" | "scratch"
 
-export function ThreadView({ slug, tab, onTab, onStatusApplied, onClose }: { slug: string; tab: ThreadTab; onTab: (t: ThreadTab) => void; onStatusApplied?: () => void; onClose?: () => void }) {
+export function ThreadView({ slug, tab, onTab, onStatusApplied, onClose, virtualized = false }: { slug: string; tab: ThreadTab; onTab: (t: ThreadTab) => void; onStatusApplied?: () => void; onClose?: () => void; virtualized?: boolean }) {
   const board = useBoard()
   const thread = threadBySlug(board, slug)
   return (
@@ -86,14 +90,14 @@ export function ThreadView({ slug, tab, onTab, onStatusApplied, onClose }: { slu
         <ScratchpadPane slug={slug} />
         </RadixTabs.Content>
       ) : (
-        <ChatView slug={slug} onTab={onTab} />
+        <ChatView slug={slug} onTab={onTab} virtualized={virtualized} />
       )}
       {thread && <ThreadLifecycleFooter thread={thread} sticky safeArea onArchived={onStatusApplied} />}
     </RadixTabs.Root>
   )
 }
 
-function ChatView({ slug, onTab }: { slug: string; onTab: (t: ThreadTab) => void }) {
+function ChatView({ slug, onTab, virtualized }: { slug: string; onTab: (t: ThreadTab) => void; virtualized: boolean }) {
   const board = useBoard()
   const thread = threadBySlug(board, slug)
   const running = thread?.runtime === "running" || thread?.runtime === "spawning"
@@ -103,6 +107,10 @@ function ChatView({ slug, onTab }: { slug: string; onTab: (t: ThreadTab) => void
   const copyTerminalCommand = useCopyTerminalCommand(slug)
 
   const q = useTranscript(slug, { poll: running })
+  const queryClient = useQueryClient()
+  const loadingEarlierRef = useRef(false)
+  const [loadingEarlier, setLoadingEarlier] = useState(false)
+  const [earlierError, setEarlierError] = useState<string | null>(null)
   // Raw server order — each message renders its `parts` in block order (fidelity). Memoized so
   // useLiveAnswering's `liveMsg` identity check compares objects from THIS same list.
   const messages = useMemo(() => q.data?.messages ?? [], [q.data])
@@ -146,9 +154,37 @@ function ChatView({ slug, onTab }: { slug: string; onTab: (t: ThreadTab) => void
   const transcriptRef = useRef<HTMLDivElement>(null)
   const count = q.data?.messages.length ?? 0
   useEffect(() => {
+    if (virtualized) return
     const scroller = transcriptRef.current
     if (scroller && scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight < 240) scroller.scrollTop = scroller.scrollHeight
-  }, [count, running])
+  }, [count, running, virtualized])
+
+  const loadEarlier = useCallback(async () => {
+    if (loadingEarlierRef.current) return
+    const current = queryClient.getQueryData<TranscriptData>(["transcript", slug])
+    const cursor = current?.beforeCursor
+    const expectedKey = current?.transcriptKey
+    if (!current?.hasEarlier || !cursor || !expectedKey) return
+    loadingEarlierRef.current = true
+    setLoadingEarlier(true)
+    setEarlierError(null)
+    try {
+      const earlier = await rpc.threadTranscriptEarlier({ slug, cursor })
+      const latest = queryClient.getQueryData<TranscriptData>(["transcript", slug])
+      if (!latest?.transcriptKey || latest.transcriptKey !== expectedKey || earlier.transcriptKey !== expectedKey) {
+        await q.refetch()
+        showToast("Transcript changed while loading history; refreshed the current session")
+        return
+      }
+      queryClient.setQueryData(["transcript", slug], prependEarlierPage(latest as Parameters<typeof prependEarlierPage>[0], earlier))
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Could not load earlier transcript history"
+      setEarlierError(message)
+    } finally {
+      loadingEarlierRef.current = false
+      setLoadingEarlier(false)
+    }
+  }, [q, queryClient, slug])
 
   return (
     <ThreadSlugContext.Provider value={slug}>
@@ -157,7 +193,31 @@ function ChatView({ slug, onTab }: { slug: string; onTab: (t: ThreadTab) => void
       data-drawer-scroll-ready={q.isPending ? "false" : "true"}
       className="flex-1 min-h-0 flex flex-col overflow-hidden outline-none"
     >
-      <div ref={transcriptRef} data-drawer-transcript-scroll className="min-h-0 flex-1 overflow-y-auto">
+      <div ref={transcriptRef} data-drawer-transcript-scroll data-standalone-transcript={virtualized || undefined} className="relative min-h-0 flex-1 overflow-y-auto">
+      {virtualized && count > 0 ? (
+        <VirtualizedThreadTranscript
+          slug={slug}
+          transcriptRef={transcriptRef}
+          transcriptKey={q.data?.transcriptKey}
+          messages={messages}
+          paired={paired}
+          answeringForMessage={answeringForMessage}
+          thread={thread}
+          nativeInputRequired={nativeInputRequired}
+          running={running}
+          copyTerminalCommand={copyTerminalCommand}
+          transportFallback={q.transportFallback}
+          isFetching={q.isFetching}
+          refresh={() => void q.refetch()}
+          retryLiveUpdates={q.retryLiveUpdates}
+          hasEarlier={q.data?.hasEarlier === true}
+          beforeCursor={q.data?.beforeCursor}
+          loadingEarlier={loadingEarlier}
+          earlierError={earlierError}
+          loadEarlier={() => void loadEarlier()}
+        />
+      ) : (
+      <>
       <InteractionStack
         thread={thread}
         className="px-6 pt-5"
@@ -302,6 +362,8 @@ function ChatView({ slug, onTab }: { slug: string; onTab: (t: ThreadTab) => void
           </>
         )}
       </div>
+      </>
+      )}
       </div>
       {/* This entire footer is deliberately non-scrolling: transcript history alone overflows. */}
       {/* Prompt box FIRST, then the background-ops strip UNDERNEATH it at the very bottom (maintainer
@@ -315,6 +377,340 @@ function ChatView({ slug, onTab }: { slug: string; onTab: (t: ThreadTab) => void
       </div>
     </RadixTabs.Content>
     </ThreadSlugContext.Provider>
+  )
+}
+
+type TranscriptTransportFallback = ReturnType<typeof useTranscript>["transportFallback"]
+type VirtualThreadRow =
+  | { key: "interactions"; kind: "interactions" }
+  | { key: "transport-fallback"; kind: "transport-fallback" }
+  | { key: string; kind: "earlier-history" }
+  | ({ kind: "message" } & VirtualTranscriptMessageRow)
+  | { key: "runtime-status"; kind: "runtime-status" }
+  | { key: string; kind: "queued"; message: ChatMessage; messageIndex: number; gap: number }
+
+function VirtualizedThreadTranscript({
+  slug,
+  transcriptRef,
+  transcriptKey,
+  messages,
+  paired,
+  answeringForMessage,
+  thread,
+  nativeInputRequired,
+  running,
+  copyTerminalCommand,
+  transportFallback,
+  isFetching,
+  refresh,
+  retryLiveUpdates,
+  hasEarlier,
+  beforeCursor,
+  loadingEarlier,
+  earlierError,
+  loadEarlier,
+}: {
+  slug: string
+  transcriptRef: React.RefObject<HTMLDivElement | null>
+  transcriptKey?: string
+  messages: ChatMessage[]
+  paired: (PairedAnswer[] | null)[]
+  answeringForMessage: LiveAnswering["answeringForMessage"]
+  thread: ThreadViewData | undefined
+  nativeInputRequired: NativeInputRequiredData | undefined
+  running: boolean
+  copyTerminalCommand: () => void
+  transportFallback: TranscriptTransportFallback
+  isFetching: boolean
+  refresh: () => void
+  retryLiveUpdates: () => void
+  hasEarlier: boolean
+  beforeCursor?: string | null
+  loadingEarlier: boolean
+  earlierError: string | null
+  loadEarlier: () => void
+}) {
+  const messageRows = useMemo(() => buildVirtualTranscriptMessageRows(
+    messages,
+    messageRendersNothing,
+    messageHeadIsMeta,
+    messageTailIsMeta,
+    STEP,
+  ), [messages])
+  const lastUserIdx = useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === "user" && !messages[i].queued) return i
+    }
+    return -1
+  }, [messages])
+  const hasRuntimeStatus = Boolean(
+    (thread?.providerFault && !thread.foreign)
+      || thread?.pendingAsk
+      || nativeInputRequired
+      || thread?.runtime === "perm-prompt"
+      || running,
+  )
+  const rows = useMemo<VirtualThreadRow[]>(() => {
+    const next: VirtualThreadRow[] = [{ key: "interactions", kind: "interactions" }]
+    if (transportFallback) next.push({ key: "transport-fallback", kind: "transport-fallback" })
+    if (hasEarlier || loadingEarlier || earlierError) {
+      next.push({ key: `earlier-history:${beforeCursor ?? "complete"}`, kind: "earlier-history" })
+    }
+    next.push(...messageRows.map((row) => ({ ...row, kind: "message" as const })))
+    if (hasRuntimeStatus) next.push({ key: "runtime-status", kind: "runtime-status" })
+    let queuedGap = hasRuntimeStatus || messageRows.length > 0 ? STEP : 0
+    messages.forEach((message, messageIndex) => {
+      if (!message.queued) return
+      const key = `queued:${message.deliveryId ?? message.sourceId ?? messageIndex}`
+      next.push({ key, kind: "queued", message, messageIndex, gap: queuedGap })
+      queuedGap = STEP
+    })
+    return next
+  }, [beforeCursor, earlierError, hasEarlier, hasRuntimeStatus, loadingEarlier, messageRows, messages, transportFallback])
+
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => transcriptRef.current,
+    getItemKey: (index) => rows[index]?.key ?? index,
+    estimateSize: (index) => {
+      const row = rows[index]
+      if (!row) return 80
+      if (row.kind === "interactions") return 1
+      if (row.kind === "earlier-history") return 42
+      if (row.kind === "transport-fallback") return 76
+      if (row.kind === "runtime-status") return 54
+      return row.kind === "message" ? 108 + row.gap : 82 + row.gap
+    },
+    overscan: 8,
+    paddingStart: 20,
+    paddingEnd: 20,
+    anchorTo: "end",
+    followOnAppend: true,
+    scrollEndThreshold: 240,
+  })
+  const [atEnd, setAtEnd] = useState(true)
+  const tailReadyRef = useRef(false)
+  const readerMovedRef = useRef(false)
+  const nearTopLoadArmedRef = useRef(true)
+  const pendingPrependAnchorRef = useRef<{ rowKey: string; viewportTop: number } | null>(null)
+  const initialTranscriptKeyRef = useRef<string | undefined>(undefined)
+
+  const requestEarlier = useCallback(() => {
+    const scroller = transcriptRef.current
+    if (scroller) {
+      const scrollerTop = scroller.getBoundingClientRect().top
+      const firstVisible = Array.from(scroller.querySelectorAll<HTMLElement>("[data-transcript-source-id]"))
+        .find((element) => element.getBoundingClientRect().bottom > scrollerTop + 1)
+      const rowKey = firstVisible?.dataset.transcriptRowKey
+      if (firstVisible && rowKey) {
+        pendingPrependAnchorRef.current = {
+          rowKey,
+          viewportTop: firstVisible.getBoundingClientRect().top - scrollerTop,
+        }
+      }
+    }
+    loadEarlier()
+  }, [loadEarlier, transcriptRef])
+
+  useLayoutEffect(() => {
+    if (!transcriptKey || rows.length === 0 || initialTranscriptKeyRef.current === transcriptKey) return
+    initialTranscriptKeyRef.current = transcriptKey
+    tailReadyRef.current = false
+    readerMovedRef.current = false
+    nearTopLoadArmedRef.current = true
+    const frame = requestAnimationFrame(() => {
+      virtualizer.scrollToEnd({ behavior: "instant" })
+      tailReadyRef.current = true
+      setAtEnd(true)
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [rows.length, transcriptKey, virtualizer])
+
+  useLayoutEffect(() => {
+    const anchor = pendingPrependAnchorRef.current
+    const scroller = transcriptRef.current
+    if (!anchor || !scroller || loadingEarlier) return
+    const alignAnchor = () => {
+      const anchoredRow = Array.from(scroller.querySelectorAll<HTMLElement>("[data-transcript-row-key]"))
+        .find((element) => element.dataset.transcriptRowKey === anchor.rowKey)
+      if (!anchoredRow) return
+      const nextTop = anchoredRow.getBoundingClientRect().top - scroller.getBoundingClientRect().top
+      scroller.scrollTop += nextTop - anchor.viewportTop
+    }
+    // Dynamic markdown/tool rows settle after TanStack's ResizeObserver measurement. Correct once
+    // synchronously and across the next two frames so the same message stays under the reader's eye.
+    alignAnchor()
+    let secondFrame = 0
+    const firstFrame = requestAnimationFrame(() => {
+      alignAnchor()
+      secondFrame = requestAnimationFrame(() => {
+        alignAnchor()
+        if (pendingPrependAnchorRef.current === anchor) pendingPrependAnchorRef.current = null
+      })
+    })
+    return () => {
+      cancelAnimationFrame(firstFrame)
+      cancelAnimationFrame(secondFrame)
+    }
+  }, [loadingEarlier, messageRows.length, transcriptRef])
+
+  useEffect(() => {
+    const scroller = transcriptRef.current
+    if (!scroller) return
+    const inspect = () => {
+      const nextAtEnd = virtualizer.isAtEnd(240)
+      setAtEnd((current) => current === nextAtEnd ? current : nextAtEnd)
+      const gate = earlierLoadGate({
+        armed: nearTopLoadArmedRef.current,
+        scrollTop: scroller.scrollTop,
+        readerMoved: tailReadyRef.current && readerMovedRef.current,
+        hasEarlier,
+        loading: loadingEarlier,
+      })
+      nearTopLoadArmedRef.current = gate.armed
+      if (gate.shouldLoad) requestEarlier()
+    }
+    const markReaderIntent = () => {
+      readerMovedRef.current = true
+      requestAnimationFrame(inspect)
+    }
+    const markKeyboardIntent = (event: KeyboardEvent) => {
+      if (!["ArrowUp", "PageUp", "Home", " "].includes(event.key)) return
+      if (scroller.scrollTop <= 480) nearTopLoadArmedRef.current = true
+      markReaderIntent()
+    }
+    const markWheelIntent = (event: WheelEvent) => {
+      if (event.deltaY < 0 && scroller.scrollTop <= 480) nearTopLoadArmedRef.current = true
+      markReaderIntent()
+    }
+    const markTouchIntent = () => {
+      if (scroller.scrollTop <= 480) nearTopLoadArmedRef.current = true
+      markReaderIntent()
+    }
+    scroller.addEventListener("scroll", inspect, { passive: true })
+    scroller.addEventListener("wheel", markWheelIntent, { passive: true })
+    scroller.addEventListener("touchstart", markTouchIntent, { passive: true })
+    scroller.addEventListener("pointerdown", markReaderIntent, { passive: true })
+    scroller.addEventListener("keydown", markKeyboardIntent)
+    const frame = requestAnimationFrame(inspect)
+    return () => {
+      cancelAnimationFrame(frame)
+      scroller.removeEventListener("scroll", inspect)
+      scroller.removeEventListener("wheel", markWheelIntent)
+      scroller.removeEventListener("touchstart", markTouchIntent)
+      scroller.removeEventListener("pointerdown", markReaderIntent)
+      scroller.removeEventListener("keydown", markKeyboardIntent)
+    }
+  }, [hasEarlier, loadingEarlier, requestEarlier, transcriptRef, virtualizer])
+
+  const virtualItems = virtualizer.getVirtualItems()
+  const totalSize = virtualizer.getTotalSize()
+  const jumpTop = Math.max(
+    12,
+    (virtualizer.scrollOffset ?? 0) + (virtualizer.scrollRect?.height ?? transcriptRef.current?.clientHeight ?? 0) - 48,
+  )
+
+  return (
+    <div
+      data-virtualized-transcript
+      data-virtual-row-count={virtualItems.length}
+      className="relative w-full"
+      style={{ height: totalSize }}
+    >
+      {virtualItems.map((virtualRow) => {
+        const row = rows[virtualRow.index]
+        if (!row) return null
+        return (
+          <div
+            key={row.key}
+            ref={virtualizer.measureElement}
+            data-index={virtualRow.index}
+            data-transcript-row-key={row.key}
+            data-transcript-source-id={row.kind === "message" ? row.message.sourceId : undefined}
+            className="absolute left-0 top-0 w-full"
+            style={{ transform: `translateY(${virtualRow.start}px)` }}
+          >
+            {row.kind === "interactions" ? (
+              <InteractionStack thread={thread} className="px-6 pt-5" autoFocusFirst />
+            ) : row.kind === "transport-fallback" ? (
+              transportFallback ? <div className="px-6 pt-3"><div
+                data-transcript-sync-fallback
+                className="flex flex-wrap items-center gap-2.5 rounded-md border border-border-strong bg-panel-2 px-3 py-2 text-[12px]"
+                title={transportFallback.kind === "payload-too-large"
+                  ? `Live payload ${transportFallback.actualBytes} bytes; socket limit ${transportFallback.maxBytes} bytes`
+                  : `Transcript read budget reached (${transportFallback.scope}); retry after about ${transportFallback.retryAfterMs}ms`}
+              >
+                <AlertTriangle size={13} className="shrink-0 text-muted" />
+                <div className="min-w-[180px] flex-1 leading-snug text-fg/85">
+                  <span className="font-medium">Live transcript updates paused.</span>{" "}
+                  {transportFallback.kind === "payload-too-large"
+                    ? "The transcript is too large for push; the last complete HTTP-loaded copy remains visible."
+                    : "The live read budget was reached; the last complete copy remains visible. Retry in a moment."}
+                </div>
+                <button type="button" disabled={isFetching} onClick={refresh} className="shrink-0 rounded-md border border-border px-2 py-1 text-[11px] text-fg/90 transition-colors hover:bg-panel disabled:opacity-40">
+                  {isFetching ? "Refreshing…" : "Refresh once"}
+                </button>
+                <button type="button" onClick={retryLiveUpdates} className="shrink-0 rounded-md border border-border px-2 py-1 text-[11px] text-fg/90 transition-colors hover:bg-panel">
+                  Retry live
+                </button>
+              </div></div> : null
+            ) : row.kind === "earlier-history" ? (
+              <div className="flex min-h-10 items-center justify-center px-6 text-[11px] text-muted" role="status">
+                {earlierError ? (
+                  <span className="flex flex-wrap items-center justify-center gap-2 text-center">
+                    <span>{earlierError}</span>
+                    <button type="button" onClick={requestEarlier} className="rounded-md border border-border px-2 py-1 text-fg/90 hover:bg-panel-2">Retry</button>
+                  </span>
+                ) : loadingEarlier ? (
+                  <span className="flex items-center gap-2"><Loader2 size={12} className="animate-spin" /> Loading earlier messages…</span>
+                ) : (
+                  <span>Scroll up to load earlier messages</span>
+                )}
+              </div>
+            ) : row.kind === "message" ? (
+              <div className="flex flex-col px-6" style={{ paddingTop: row.gap }}>
+                <Message
+                  m={row.message}
+                  answering={answeringForMessage(row.message)}
+                  showSendButton
+                  paired={paired[row.messageIndex]}
+                />
+              </div>
+            ) : row.kind === "runtime-status" ? (
+              <div className="px-6" style={{ paddingTop: STEP }}>
+                {thread?.providerFault && !thread.foreign ? (
+                  <ProviderFaultCard slug={slug} fault={thread.providerFault} retryText={lastUserIdx >= 0 ? messages[lastUserIdx]?.text : undefined} />
+                ) : thread?.pendingAsk ? (
+                  <PendingAskCard ask={thread.pendingAsk} onTerminal={copyTerminalCommand} />
+                ) : nativeInputRequired ? (
+                  <NativeInputRequiredCard input={nativeInputRequired} onTerminal={copyTerminalCommand} />
+                ) : thread?.runtime === "perm-prompt" ? (
+                  <PermPromptBanner onTerminal={copyTerminalCommand} />
+                ) : running ? (
+                  <WorkingIndicator since={thread?.lastUserAt} />
+                ) : null}
+              </div>
+            ) : (
+              <div className="flex flex-col px-6" style={{ paddingTop: row.gap }}>
+                <Message m={row.message} paired={paired[row.messageIndex]} />
+              </div>
+            )}
+          </div>
+        )
+      })}
+      {!atEnd && (
+        <button
+          type="button"
+          data-jump-to-latest
+          onClick={() => virtualizer.scrollToEnd({ behavior: "smooth" })}
+          className="absolute right-4 z-20 flex items-center gap-1.5 rounded-full border border-border-strong bg-elevated px-3 py-1.5 text-[11px] font-medium text-fg shadow-lg shadow-black/30 hover:bg-panel-2"
+          style={{ top: jumpTop }}
+        >
+          <ArrowDown size={12} />
+          Jump to latest
+        </button>
+      )}
+    </div>
   )
 }
 
@@ -486,6 +882,19 @@ export function ThreadHeader({ slug, tab, onStatusApplied, onClose }: { slug: st
             doneBusy={markComplete.isPending}
             onStatusApplied={onStatusApplied}
           />
+          {onClose && (
+            <Tooltip label="Open in new tab">
+              <a
+                href={standaloneThreadHref(slug)}
+                target="_blank"
+                rel="noopener"
+                aria-label="Open in new tab"
+                className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted outline-none transition-colors hover:bg-panel-2 hover:text-fg focus-visible:ring-1 focus-visible:ring-fg/60"
+              >
+                <ArrowUpRight size={14} />
+              </a>
+            </Tooltip>
+          )}
         </div>
         {/* Close-X for the DRAWER context (onClose passed by ThreadSheet) — parity with the Settings,
             sub-agent, and Doc drawers, all of which carry a corner "Close". Wired to the SAME animated

--- a/ui/packages/web/src/components/StandaloneThreadPage.tsx
+++ b/ui/packages/web/src/components/StandaloneThreadPage.tsx
@@ -87,7 +87,7 @@ export function StandaloneThreadPage({ slug }: { slug: string }) {
               </a>
             </div>
           ) : (
-            <ThreadView slug={slug} tab={effectiveTab} onTab={setTab} virtualized />
+            <ThreadView slug={slug} tab={effectiveTab} onTab={setTab} virtualized showReturnToQueue />
           )}
         </main>
         <Toaster />

--- a/ui/packages/web/src/components/StandaloneThreadPage.tsx
+++ b/ui/packages/web/src/components/StandaloneThreadPage.tsx
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import { seedBoard } from "../store.ts"
+import { useBoard } from "../hooks.ts"
+import { rpc } from "../api/rpc.ts"
+import { displayTitle } from "../groups.ts"
+import { resolveThreadRoute } from "../lib/threadRouteState.ts"
+import {
+  clampThreadTab,
+  readThreadTab,
+  resolveThreadTabCapabilities,
+  writeThreadTab,
+  type ScopedThreadTabCapabilities,
+} from "../lib/threadTabState.ts"
+import { ThreadView, type ThreadTab } from "./ChatView.tsx"
+import { TooltipProvider } from "./Tooltip.tsx"
+import { Toaster } from "./Toaster.tsx"
+
+export function StandaloneThreadPage({ slug }: { slug: string }) {
+  const board = useBoard()
+  const route = resolveThreadRoute(board, slug)
+  const thread = route.kind === "found" ? route.thread : undefined
+  const projectDir = board?.projectDir
+  const scope = projectDir ? `${projectDir}\0${slug}` : undefined
+  const rememberedCapabilitiesRef = useRef<ScopedThreadTabCapabilities | undefined>(undefined)
+  const resolvedCapabilities = resolveThreadTabCapabilities(
+    scope,
+    thread ? { scratch: Boolean(thread.scratchpadPath) } : undefined,
+    rememberedCapabilitiesRef.current,
+  )
+  rememberedCapabilitiesRef.current = resolvedCapabilities.remembered
+  const loadedScopeRef = useRef<string | null>(projectDir && thread ? scope ?? null : null)
+  const [tab, setTabState] = useState<ThreadTab>(() => (
+    projectDir && thread ? readThreadTab(projectDir, slug) : "chat"
+  ))
+  const requestedTab = loadedScopeRef.current === scope ? tab : "chat"
+  const effectiveTab = clampThreadTab(requestedTab, resolvedCapabilities.capabilities)
+
+  useEffect(() => {
+    rpc.board().then(seedBoard).catch(() => {})
+  }, [])
+
+  useEffect(() => {
+    if (!projectDir || !scope || !resolvedCapabilities.authoritative) return
+    if (loadedScopeRef.current === scope) return
+    loadedScopeRef.current = scope
+    setTabState(readThreadTab(projectDir, slug))
+  }, [projectDir, resolvedCapabilities.authoritative, scope, slug])
+
+  const setTab = useCallback((next: ThreadTab) => {
+    if (projectDir) writeThreadTab(projectDir, slug, next)
+    setTabState(next)
+  }, [projectDir, slug])
+
+  const atRest = thread?.runtime === "turn-idle" || thread?.runtime === "exited" || thread?.runtime === "none"
+  useEffect(() => {
+    if (!thread || !atRest) return
+    rpc.threadSeen({ slug }).catch(() => {})
+  }, [atRest, slug, thread?.lastActivityAt])
+
+  useEffect(() => {
+    const projectLabel = board?.projectLabel ?? board?.projectName
+    const threadLabel = thread ? displayTitle(thread) : slug
+    document.title = projectLabel
+      ? `${threadLabel} · ${projectLabel} · fray`
+      : `${threadLabel} · fray`
+  }, [board?.projectLabel, board?.projectName, slug, thread])
+
+  return (
+    <TooltipProvider>
+      <div className="h-dvh min-h-0 bg-bg px-0 text-sm text-fg sm:px-5">
+        <main
+          data-standalone-thread
+          className="mx-auto flex h-full w-full max-w-[900px] min-w-0 flex-col overflow-hidden border-border bg-panel sm:border-x"
+        >
+          {route.kind === "loading" ? (
+            <div className="flex flex-1 items-center justify-center" role="status" aria-label="Loading thread">
+              <span className="block h-5 w-5 animate-spin rounded-full border-2 border-muted/50 border-t-transparent" />
+            </div>
+          ) : route.kind === "missing" ? (
+            <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6 text-center">
+              <div>
+                <h1 className="font-medium text-fg">Thread unavailable</h1>
+                <p className="mt-1 text-muted">Thread “{slug}” was not found in this project.</p>
+              </div>
+              <a href="/" className="rounded-md border border-border px-3 py-1.5 text-[12px] text-fg/90 hover:bg-panel-2">
+                Return to queue
+              </a>
+            </div>
+          ) : (
+            <ThreadView slug={slug} tab={effectiveTab} onTab={setTab} virtualized />
+          )}
+        </main>
+        <Toaster />
+      </div>
+    </TooltipProvider>
+  )
+}

--- a/ui/packages/web/src/lib/standaloneThreadRoute.test.ts
+++ b/ui/packages/web/src/lib/standaloneThreadRoute.test.ts
@@ -1,0 +1,15 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import { parseStandaloneThreadPath, standaloneThreadHref } from "./standaloneThreadRoute.ts"
+
+test("standalone thread links encode slugs and round-trip through the parser", () => {
+  const href = standaloneThreadHref("fix queue/spacing")
+  assert.equal(href, "/thread/fix%20queue%2Fspacing/full")
+  assert.equal(parseStandaloneThreadPath(href), "fix queue/spacing")
+})
+
+test("standalone parsing rejects drawer, extra-segment, and malformed routes", () => {
+  assert.equal(parseStandaloneThreadPath("/thread/example"), null)
+  assert.equal(parseStandaloneThreadPath("/thread/example/full/more"), null)
+  assert.equal(parseStandaloneThreadPath("/thread/%/full"), null)
+})

--- a/ui/packages/web/src/lib/standaloneThreadRoute.ts
+++ b/ui/packages/web/src/lib/standaloneThreadRoute.ts
@@ -1,0 +1,13 @@
+export function standaloneThreadHref(slug: string): string {
+  return `/thread/${encodeURIComponent(slug)}/full`
+}
+
+export function parseStandaloneThreadPath(path: string): string | null {
+  const match = path.match(/^\/thread\/([^/]+)\/full$/)
+  if (!match) return null
+  try {
+    return decodeURIComponent(match[1])
+  } catch {
+    return null
+  }
+}

--- a/ui/packages/web/src/lib/virtualTranscript.test.ts
+++ b/ui/packages/web/src/lib/virtualTranscript.test.ts
@@ -1,0 +1,65 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import type { ChatMessage } from "../hooks.ts"
+import { buildVirtualTranscriptMessageRows, earlierLoadGate } from "./virtualTranscript.ts"
+
+function message(over: Partial<ChatMessage>): ChatMessage {
+  return {
+    role: "assistant",
+    text: "message",
+    tools: [],
+    sourceId: "message",
+    ...over,
+  } as ChatMessage
+}
+
+test("virtual transcript rows omit queued and empty messages while preserving source keys", () => {
+  const rows = buildVirtualTranscriptMessageRows(
+    [
+      message({ sourceId: "first" }),
+      message({ sourceId: "empty", text: "" }),
+      message({ sourceId: "queued", queued: true }),
+      message({ sourceId: "last" }),
+    ],
+    (candidate) => candidate.text === "",
+    () => false,
+    () => false,
+    14,
+  )
+  assert.deepEqual(rows.map(({ key, messageIndex, gap }) => ({ key, messageIndex, gap })), [
+    { key: "first", messageIndex: 0, gap: 0 },
+    { key: "last", messageIndex: 3, gap: 14 },
+  ])
+})
+
+test("virtual transcript rows keep the tight rhythm between adjacent meta rows", () => {
+  const rows = buildVirtualTranscriptMessageRows(
+    [message({ sourceId: "a" }), message({ sourceId: "b" }), message({ sourceId: "c" })],
+    () => false,
+    (candidate) => candidate.sourceId !== "c",
+    (candidate) => candidate.sourceId !== "b",
+    14,
+  )
+  assert.deepEqual(rows.map((row) => row.gap), [0, 6, 14])
+})
+
+test("legacy duplicate rows still receive unique render keys", () => {
+  const duplicate = message({ sourceId: undefined })
+  const rows = buildVirtualTranscriptMessageRows([duplicate, duplicate], () => false, () => false, () => false, 14)
+  assert.notEqual(rows[0]?.key, rows[1]?.key)
+})
+
+test("earlier-page loading fires once at the top until the reader leaves or explicitly rearms", () => {
+  const first = earlierLoadGate({ armed: true, scrollTop: 0, readerMoved: true, hasEarlier: true, loading: false })
+  assert.deepEqual(first, { armed: false, shouldLoad: true })
+  assert.deepEqual(
+    earlierLoadGate({ armed: first.armed, scrollTop: 0, readerMoved: true, hasEarlier: true, loading: false }),
+    { armed: false, shouldLoad: false },
+  )
+  const leftTop = earlierLoadGate({ armed: false, scrollTop: 700, readerMoved: true, hasEarlier: true, loading: false })
+  assert.deepEqual(leftTop, { armed: true, shouldLoad: false })
+  assert.equal(
+    earlierLoadGate({ armed: leftTop.armed, scrollTop: 400, readerMoved: true, hasEarlier: true, loading: false }).shouldLoad,
+    true,
+  )
+})

--- a/ui/packages/web/src/lib/virtualTranscript.ts
+++ b/ui/packages/web/src/lib/virtualTranscript.ts
@@ -1,0 +1,58 @@
+import type { ChatMessage } from "../hooks.ts"
+
+export interface VirtualTranscriptMessageRow {
+  key: string
+  message: ChatMessage
+  messageIndex: number
+  gap: number
+}
+
+export interface EarlierLoadGateInput {
+  armed: boolean
+  scrollTop: number
+  readerMoved: boolean
+  hasEarlier: boolean
+  loading: boolean
+}
+
+export function earlierLoadGate(input: EarlierLoadGateInput): { armed: boolean; shouldLoad: boolean } {
+  const armed = input.scrollTop > 640 ? true : input.armed
+  const shouldLoad = armed
+    && input.readerMoved
+    && input.scrollTop <= 480
+    && input.hasEarlier
+    && !input.loading
+  return { armed: shouldLoad ? false : armed, shouldLoad }
+}
+
+function legacyMessageKey(message: ChatMessage): string {
+  return `legacy:${message.role}:${message.kind ?? "message"}:${message.at ?? ""}:${message.text}`
+}
+
+export function buildVirtualTranscriptMessageRows(
+  messages: readonly ChatMessage[],
+  rendersNothing: (message: ChatMessage) => boolean,
+  headIsMeta: (message: ChatMessage) => boolean,
+  tailIsMeta: (message: ChatMessage) => boolean,
+  step: number,
+): VirtualTranscriptMessageRow[] {
+  const rows: VirtualTranscriptMessageRow[] = []
+  const keyCounts = new Map<string, number>()
+  let previousTailIsMeta: boolean | null = null
+
+  messages.forEach((message, messageIndex) => {
+    if (message.queued || rendersNothing(message)) return
+    const baseKey = message.sourceId ?? legacyMessageKey(message)
+    const duplicate = keyCounts.get(baseKey) ?? 0
+    keyCounts.set(baseKey, duplicate + 1)
+    rows.push({
+      key: duplicate === 0 ? baseKey : `${baseKey}:${duplicate}`,
+      message,
+      messageIndex,
+      gap: previousTailIsMeta === null ? 0 : previousTailIsMeta && headIsMeta(message) ? 6 : step,
+    })
+    previousTailIsMeta = tailIsMeta(message)
+  })
+
+  return rows
+}

--- a/ui/packages/web/src/main.tsx
+++ b/ui/packages/web/src/main.tsx
@@ -3,16 +3,19 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import "@xterm/xterm/css/xterm.css"
 import "./styles.css"
 import { App } from "./App.tsx"
+import { StandaloneThreadPage } from "./components/StandaloneThreadPage.tsx"
 import { connectSync } from "./api/socket.ts"
 import { initFont } from "./lib/font.ts"
 import { installExternalLinkInterceptor } from "./lib/external-links.ts"
 import { installLocalFileLinkInterceptor } from "./lib/local-file-links.ts"
 import { installThreadLinkInterceptor } from "./lib/thread-links.ts"
 import { primeRoute } from "./lib/router.ts"
+import { parseStandaloneThreadPath } from "./lib/standaloneThreadRoute.ts"
 
 const settingsFixture = typeof window !== "undefined" && window.location.pathname.endsWith("/settings-formatting-fixture.html")
+const standaloneThreadSlug = typeof window !== "undefined" ? parseStandaloneThreadPath(window.location.pathname) : null
 
-if (!settingsFixture) {
+if (!settingsFixture && !standaloneThreadSlug) {
   // Adopt a cold/deep URL before React takes its first store snapshot. startRouter installs the ongoing
   // store/history listeners from App; this synchronous seed is what makes the initial drawer real.
   primeRoute()
@@ -37,7 +40,7 @@ if (!settingsFixture) {
 if (!settingsFixture) {
   createRoot(document.getElementById("root")!).render(
     <QueryClientProvider client={queryClient}>
-      <App />
+      {standaloneThreadSlug ? <StandaloneThreadPage slug={standaloneThreadSlug} /> : <App />}
     </QueryClientProvider>,
   )
 }

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5
         version: 5.101.2(react@19.2.7)
+      '@tanstack/react-virtual':
+        specifier: ^3.14.7
+        version: 3.14.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@xstate/react':
         specifier: ^6.1.0
         version: 6.1.0(@types/react@19.2.17)(react@19.2.7)(xstate@5.32.3)
@@ -1432,6 +1435,15 @@ packages:
     resolution: {integrity: sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/react-virtual@3.14.7':
+    resolution: {integrity: sha512-11uSrj77IDijNBqizD4lY4y1laMyRrqMLSxjnWy5CvWkCjyRDW+gGmxYq0lwQKVas/sq7zyzYWXbL/BvBzR32g==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.17.5':
+    resolution: {integrity: sha512-AXfBC3sq6PuYSwyxYORqqgHCNjPGAvKJvZuBBJ1klhztWBB5cgqgwsq8+fNfaQJG7/K4xYBja9S90QFn2zmQAg==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -3501,6 +3513,14 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.101.2
       react: 19.2.7
+
+  '@tanstack/react-virtual@3.14.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.5
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@tanstack/virtual-core@3.17.5': {}
 
   '@tybys/wasm-util@0.10.3':
     dependencies:


### PR DESCRIPTION
## Summary

- add a drawer-header action that opens a centered, sidebar-free standalone thread tab with the shared header, lifecycle controls, and complete composer
- virtualize the transcript DOM, start at the tail, load turn-aligned history upward with stable-key anchoring, and expose a jump-to-latest control
- make history keyboard-operable and provide an explicit return-to-queue route
- update the portable-monitor assertion to follow the generated worker-prompt golden files after the old prompt files were deleted

## Verification

- `pnpm test` — 1,517 pass, 9 skip, 0 fail
- `pnpm --filter @fray-ui/web build`
- focused route, pagination, tab-state, and virtual-transcript tests — 19 pass
- `node scripts/set-version.ts --check && node scripts/sync-portable-monitors.mjs --check && node --test monitors/*.test.mjs` — 16 pass
- real Chromium QA at 1500x1000 and 390x844: drawer launch, auto-tail, bounded mounted rows, upward loading and anchor preservation, jump-to-latest, model and permission menus, keyboard Home pagination, missing-thread state, return navigation, console/page errors, and cleanup

## Known baseline

`pnpm typecheck` reaches three existing errors in `GithubPickerModal.tsx` and `githubDispatch.ts`; this branch does not modify those files.