### PR TITLE
fix(quota): recheck actually re-hits — outcome-based memo TTL for the Claude usage endpoint

### DIFF
--- a/ui/packages/server/src/backend/claude-quota.ts
+++ b/ui/packages/server/src/backend/claude-quota.ts
@@ -29,9 +29,15 @@ const OAUTH_BETA = "oauth-2025-04-20"
 // The endpoint rate-limits callers without a claude-code User-Agent; a plausible recent version is
 // enough (it gates by product, not exact version).
 const USER_AGENT = "claude-code/2.0.0"
-// Undocumented endpoint — cache generously so a 60s UI poll can't hammer it. 3 min is the community
-// floor observed to avoid persistent 429s.
-const TTL_MS = 3 * 60_000
+// Undocumented endpoint that 429s aggressively, so the memo TTL is chosen by OUTCOME rather than a flat
+// interval. A HEALTHY read is cached generously (a 60s UI poll must not hammer it — the original intent).
+// But a FAILURE must NOT be cached that long: the chip's recheck (opening its popover forces a fresh
+// quota read; an unavailable read also degraded-polls at 15s) would just replay a stale "unreachable" for
+// minutes, so a transient blip would look permanent. A rate-limit still backs off (the endpoint asked us
+// to), but every OTHER failure clears within one degraded poll so the very next read re-hits live.
+const OK_TTL_MS = 3 * 60_000 // healthy: cache generously (the community 429-avoidance floor)
+const RATE_LIMIT_TTL_MS = 60_000 // 429/529: respect the backoff, but recover in a minute, not three
+const FAIL_TTL_MS = 10_000 // unreachable/timeout/5xx/malformed/not-logged-in: recover within one 15s poll
 
 function claudeConfigDir(): string {
   const override = process.env.CLAUDE_CONFIG_DIR
@@ -116,24 +122,38 @@ export function parseClaudeUsage(body: unknown, planType?: string): ProviderQuot
   return { status: "ok", planType, windows }
 }
 
-const memo = new Map<string, { at: number; quota: ProviderQuota }>()
+const memo = new Map<string, { at: number; ttl: number; quota: ProviderQuota }>()
+
+// Injectable seams so the memo's outcome→TTL recovery behavior is unit-testable without the live
+// network or a real credential store. All default to the real implementations.
+export interface ClaudeQuotaDeps {
+  now?: () => number
+  fetchImpl?: typeof fetch
+  readToken?: (configDir: string) => Promise<string | undefined>
+}
 
 // The Claude provider quota (RPC-facing). Reads the OAuth token, calls the usage endpoint with the
-// required headers, and degrades to "unavailable" on any error. Cached ≥3 min. Never throws.
-export async function readClaudeQuota(configDir = claudeConfigDir()): Promise<ProviderQuota> {
-  const now = Date.now()
+// required headers, and degrades to "unavailable" on any error — never throws. The result is memoized,
+// but for a duration that depends on the OUTCOME (see the TTL constants): a healthy read sticks for
+// minutes, a rate-limit backs off, and any other failure clears fast so a recheck actually re-hits.
+export async function readClaudeQuota(configDir = claudeConfigDir(), deps: ClaudeQuotaDeps = {}): Promise<ProviderQuota> {
+  const now = (deps.now ?? Date.now)()
+  const doFetch = deps.fetchImpl ?? fetch
+  const readToken = deps.readToken ?? readAccessToken
   const hit = memo.get(configDir)
-  if (hit && now - hit.at < TTL_MS) return hit.quota
+  if (hit && now - hit.at < hit.ttl) return hit.quota
   let quota: ProviderQuota
+  // Default to the short failure TTL; only a healthy read or a rate-limit widens it below.
+  let ttl = FAIL_TTL_MS
   try {
-    const token = await readAccessToken(configDir)
+    const token = await readToken(configDir)
     if (!token) {
       quota = { status: "unavailable", windows: [], detail: "Not logged in to Claude" }
     } else {
       // Hard 5s timeout: the endpoint is unstable/rate-limited, and readQuota awaits this alongside the
       // clean Codex read — an un-bounded stall would hold the whole quota RPC open (undici's default
       // header timeout is minutes). AbortSignal.timeout throws on fire → caught below → "unavailable".
-      const res = await fetch(USAGE_URL, {
+      const res = await doFetch(USAGE_URL, {
         headers: {
           Authorization: `Bearer ${token}`,
           "anthropic-beta": OAUTH_BETA,
@@ -144,15 +164,19 @@ export async function readClaudeQuota(configDir = claudeConfigDir()): Promise<Pr
       })
       if (!res.ok) {
         quota = { status: "unavailable", windows: [], detail: `Usage endpoint ${res.status}` }
+        // 429 (rate limited) / 529 (overloaded) are the endpoint telling us to slow down — back off
+        // longer than a plain failure so a recheck can't hammer it back into the same wall.
+        if (res.status === 429 || res.status === 529) ttl = RATE_LIMIT_TTL_MS
       } else {
         const body = (await res.json()) as Record<string, unknown>
         const planType = typeof body.plan_type === "string" ? body.plan_type : undefined
         quota = parseClaudeUsage(body, planType)
+        if (quota.status === "ok") ttl = OK_TTL_MS
       }
     }
   } catch {
     quota = { status: "unavailable", windows: [], detail: "Usage endpoint unreachable" }
   }
-  memo.set(configDir, { at: now, quota })
+  memo.set(configDir, { at: now, ttl, quota })
   return quota
 }

--- a/ui/packages/server/src/backend/quota.test.ts
+++ b/ui/packages/server/src/backend/quota.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
 import { parseCodexQuotaFromRollout } from "./codex-quota.ts"
-import { parseClaudeUsage, tokenFromCredentialsJson } from "./claude-quota.ts"
+import { parseClaudeUsage, tokenFromCredentialsJson, readClaudeQuota } from "./claude-quota.ts"
 
 // ---- Codex rollout parsing ----
 
@@ -114,4 +114,89 @@ test("claude creds: garbage / empty / no token → undefined, never throws", () 
   assert.equal(tokenFromCredentialsJson("null"), undefined)
   assert.equal(tokenFromCredentialsJson(JSON.stringify({ claudeAiOauth: { accessToken: "" } })), undefined)
   assert.equal(tokenFromCredentialsJson(JSON.stringify({ other: 1 })), undefined)
+})
+
+// ---- Quota memo: outcome-based TTL (the "recheck actually re-hits" fix) ----
+// readClaudeQuota memoizes per configDir; a FLAT 3-min cache used to strand a transient failure for
+// minutes, so a chip stuck on "Usage endpoint unreachable" ignored every recheck. These drive the real
+// function through injected clock/fetch/token seams (no network, no credential store) and assert the
+// cache clears — or holds — for the RIGHT duration per outcome. Each test uses a unique configDir so the
+// module-global memo never bleeds across tests.
+
+const okBody = { five_hour: { utilization: 20, reset_at: "2030-01-01T00:00:00Z" } }
+// A fetch stub that counts calls and yields a scripted status/body each time. The call counter is a
+// LIVE getter (Object.defineProperty, not Object.assign — the latter would copy the getter's value once
+// and freeze it at 0).
+function countingFetch(steps: Array<{ status: number; body?: unknown } | "throw">) {
+  let calls = 0
+  const impl = (async () => {
+    const step = steps[Math.min(calls, steps.length - 1)]!
+    calls++
+    if (step === "throw") throw new Error("network down")
+    return { ok: step.status >= 200 && step.status < 300, status: step.status, json: async () => step.body ?? {} }
+  }) as unknown as typeof fetch
+  Object.defineProperty(impl, "calls", { get: () => calls })
+  return impl as typeof fetch & { readonly calls: number }
+}
+const withToken = async () => "tok-test"
+let dirN = 0
+const freshDir = () => `/nonexistent-fray-quota-test-${++dirN}`
+
+test("quota memo: a transient failure clears within FAIL_TTL so the next read re-hits (not stranded 3 min)", async () => {
+  const dir = freshDir()
+  const fetchImpl = countingFetch(["throw", { status: 200, body: okBody }])
+  const first = await readClaudeQuota(dir, { now: () => 0, fetchImpl, readToken: withToken })
+  assert.equal(first.status, "unavailable")
+  assert.equal(first.detail, "Usage endpoint unreachable")
+  assert.equal(fetchImpl.calls, 1)
+  // Within the 10s failure window → served from cache, endpoint NOT re-hit.
+  const cached = await readClaudeQuota(dir, { now: () => 5_000, fetchImpl, readToken: withToken })
+  assert.equal(cached.status, "unavailable")
+  assert.equal(fetchImpl.calls, 1)
+  // Past the failure window → live re-hit, and it recovers to a healthy read.
+  const recovered = await readClaudeQuota(dir, { now: () => 11_000, fetchImpl, readToken: withToken })
+  assert.equal(recovered.status, "ok")
+  assert.equal(fetchImpl.calls, 2)
+})
+
+test("quota memo: a healthy read is cached generously (1 min) but DOES expire (~3 min), not forever", async () => {
+  const dir = freshDir()
+  const fetchImpl = countingFetch([{ status: 200, body: okBody }])
+  const first = await readClaudeQuota(dir, { now: () => 0, fetchImpl, readToken: withToken })
+  assert.equal(first.status, "ok")
+  const oneMinLater = await readClaudeQuota(dir, { now: () => 60_000, fetchImpl, readToken: withToken })
+  assert.equal(oneMinLater.status, "ok")
+  assert.equal(fetchImpl.calls, 1) // still cached at 1 min (< 3 min OK TTL)
+  // Past the 3-min OK TTL → live re-hit. Asserting the EXPIRY (not just that it holds) guards against
+  // an OK_TTL accidentally set too high / infinite, which the "still cached" check alone would pass.
+  const past = await readClaudeQuota(dir, { now: () => 181_000, fetchImpl, readToken: withToken })
+  assert.equal(past.status, "ok")
+  assert.equal(fetchImpl.calls, 2)
+})
+
+test("quota memo: a 429 backs off ~1 min — longer than a plain failure, shorter than the old 3 min", async () => {
+  const dir = freshDir()
+  const fetchImpl = countingFetch([{ status: 429 }, { status: 200, body: okBody }])
+  const limited = await readClaudeQuota(dir, { now: () => 0, fetchImpl, readToken: withToken })
+  assert.equal(limited.detail, "Usage endpoint 429")
+  // At 30s the 429 is still cached — a recheck must NOT hammer the endpoint back into the wall.
+  await readClaudeQuota(dir, { now: () => 30_000, fetchImpl, readToken: withToken })
+  assert.equal(fetchImpl.calls, 1)
+  // Past ~1 min it re-hits (and would have stayed stranded under the old flat 3-min cache).
+  const recovered = await readClaudeQuota(dir, { now: () => 61_000, fetchImpl, readToken: withToken })
+  assert.equal(recovered.status, "ok")
+  assert.equal(fetchImpl.calls, 2)
+})
+
+test("quota memo: not-logged-in clears fast so a fresh sign-in recovers within a poll", async () => {
+  const dir = freshDir()
+  const fetchImpl = countingFetch([{ status: 200, body: okBody }])
+  let token: string | undefined = undefined
+  const readToken = async () => token
+  const out = await readClaudeQuota(dir, { now: () => 0, fetchImpl, readToken })
+  assert.equal(out.detail, "Not logged in to Claude")
+  assert.equal(fetchImpl.calls, 0) // no token → endpoint never called
+  token = "tok-now-present"
+  const after = await readClaudeQuota(dir, { now: () => 11_000, fetchImpl, readToken })
+  assert.equal(after.status, "ok")
 })

--- a/ui/packages/server/src/quota.ts
+++ b/ui/packages/server/src/quota.ts
@@ -45,6 +45,10 @@ function fixture(name: string): QuotaSnapshot | undefined {
       }
     case "claude-unavailable":
       return { claude: { status: "unavailable", windows: [], detail: "Not logged in to Claude" }, codex: codexOk }
+    case "claude-endpoint-down":
+      // The authed-but-endpoint-failing case (the user-reported "Usage endpoint unreachable"): the chip
+      // is signed in yet has no window data, so the popover shows the failure detail + the recheck spinner.
+      return { claude: { status: "unavailable", windows: [], detail: "Usage endpoint unreachable" }, codex: codexOk }
     case "codex-real":
       // REAL Codex quota from the local rollout tail, with Claude stubbed unavailable so QA never
       // live-calls the undocumented Claude endpoint. Proves the clean Codex path end-to-end in the UI.


### PR DESCRIPTION
## The bug

Clicking the sidebar quota chip when it reads **"Usage endpoint unreachable"** looked like it did nothing — the recheck never seemed to fire at a reasonable time.

The chip's recheck wiring was fine (opening its popover already calls `refetchQueries(["quota"])`, and an unavailable read degraded-polls at 15s). The problem was server-side: [`readClaudeQuota`](../blob/main/ui/packages/server/src/backend/claude-quota.ts) memoized the result — **including failures** — for a flat `TTL_MS = 3 * 60_000`. So every recheck within that window just replayed the stale cached failure for up to **3 minutes**. The click *was* firing; the server kept handing back a cached "unreachable."

The 3-min cache exists for a good reason (the undocumented OAuth usage endpoint 429s aggressively, so the happy-path poll must not hammer it) — but caching a *transient* blip that long strands it for minutes.

## The fix

Choose the memo TTL by **outcome** instead of a flat interval:

| Outcome | TTL | Why |
|---|---|---|
| healthy read | 3 min | unchanged — preserves the 429-avoidance floor on the happy path |
| `429` / `529` | 60s | respect the endpoint's backoff, but recover in a minute not three |
| every other failure | 10s | unreachable / timeout / 5xx / malformed / not-logged-in — recovers within one 15s degraded poll |

`readClaudeQuota` also gains injectable `{ now, fetchImpl, readToken }` deps (real defaults) so the recovery timing is unit-testable without the live network or a credential store. `quota.ts` adds a **dev-only** `claude-endpoint-down` fixture (gated by `NODE_ENV !== "production"`) — the exact authed-but-endpoint-failing state — for UI QA.

## Verification

**Unit** — 4 new tests in `quota.test.ts` lock the per-outcome behavior (failure recovers fast, healthy caches ~3 min *and expires*, 429 backs off ~1 min, not-logged-in recovers fast). Full server suite **1029 green**.

**End-to-end** in an isolated adhoc stack (real server, headless browser):
- Claude chip renders the em dash; its popover shows **"Usage endpoint unreachable"**, and opening it fires a fresh `/rpc/quota` + `/rpc/authStatus` (the recheck).
- Signed-out → both chips em-dash → popover **"Signed out of Claude" + Sign in** → opens the SignInModal (`claude auth login`).
- Narrow 420px viewport clean, no console errors.

## Review

A fresh-context adversarial review found **no hard defects** (all TTL branches correct, detached `fetch`/`Date.now` safe, memo keying + test isolation collision-free, back-compat clean). Its one actionable note — the healthy-cache test didn't assert 3-min *expiry* — was folded in.

## Deliberate tradeoff

Shortening the non-429 failure TTL to 10s raises failure-path endpoint load during a real outage from ~0.33/min to ~4/min. Acceptable: a network/5xx outage isn't worsened by more calls, and the one path that actually rate-limits (429/529) is protected at 60s and self-corrects (a 10s retry that provokes a 429 immediately escalates that key to the 60s backoff).

## Note (not part of this change)

The **web** package typecheck is red on `main` already (`githubDispatch.ts`, `GithubPickerModal.tsx` — the in-flight codex-dispatch work). This PR is server/shared-only; the server+shared+cli typecheck and full server test suite are green.

https://claude.ai/code/session_01Gb4DPdDs8XBjc4jdoJbrRt