### PR TITLE
fix(board): surface a crashed parent that was resting on a sub-agent

### DIFF
--- a/ui/packages/server/src/board.test.ts
+++ b/ui/packages/server/src/board.test.ts
@@ -436,6 +436,59 @@ test("deriveNeedsYou: crash net — pane EXITED while the turn was in-flight que
   assert.equal(deriveNeedsYou(row({ seen_at: LATER }), tele({ turn: "idle", lastActivityAt: T0 }), "exited"), true)
 })
 
+test("deriveNeedsYou: an EXITED parent surfaces even when a SUB-AGENT still reads 'running' (crash mid-background-work)", () => {
+  // A sub-agent cannot outlive its parent pane. A crashed/slept worker that rested on a sub-agent leaves
+  // it "running" in telemetry (subAgentViews has no paneDead guard, unlike bgShellViews) until it goes
+  // stale — or forever if its output file never resolved. The dead parent MUST still surface. This once
+  // silently dangled: hasLiveBackgroundWork buried the exited row instead of queuing it (found 2026-07-21).
+  const childRunning = tele({ subAgents: [{ label: "c", startedAt: T0, state: "running", id: "a1" }], lastActivityAt: LATER })
+  assert.equal(deriveNeedsYou(row({ seen_at: LATER }), childRunning, "exited"), true, "dead parent w/ 'running' sub-agent surfaces")
+  // Regression guard for the live case: a LIVE parent (turn-idle) resting on a running child stays held.
+  assert.equal(deriveNeedsYou(row({ seen_at: T0 }), childRunning, "turn-idle"), false)
+  // A dead parent whose child has already gone STALE also surfaces — via bare rest, not the bgwork arm
+  // (stale ≠ "running", so hasLiveBackgroundWork never buries it and it is not counted as live work).
+  const childStale = tele({ subAgents: [{ label: "c", startedAt: T0, state: "stale", id: "a1" }], lastActivityAt: LATER })
+  assert.equal(deriveNeedsYou(row({ seen_at: LATER }), childStale, "exited"), true, "dead parent w/ stale child surfaces via bare rest")
+})
+
+test("board: an EXITED parent resting on a 'running' sub-agent surfaces as a stalled crash, not buried", async () => {
+  // End-to-end through board assembly: a dead pane (no tmux → runtime 'exited') whose telemetry still
+  // reports a running sub-agent must enter Queue (needsYou) AND card as a crash/stall (crashed), so the
+  // human sees it instead of it silently dangling under stale child liveness.
+  const dir = mkdtempSync(join(tmpdir(), "fray-board-crash-bgwork-"))
+  const project: Project = { dir, id: "board-crash-bgwork", name: "fixture", label: "fixture", stateDir: dir, cwdSlug: "fixture" }
+  const storage = createStorage(join(dir, "ui.db"))
+  storage.upsertSession(row({ slug: "dead-parent", tmux_name: "fray-dead-parent", seen_at: LATER }))
+  // Sibling with an already-STALE child: it must still surface, but as a bare rest, NOT a stalled crash.
+  storage.upsertSession(row({ slug: "dead-parent-stale", tmux_name: "fray-dead-parent-stale", seen_at: LATER }))
+  const tailer = {
+    get: (slug: string) => tele({
+      turn: "idle",
+      subAgents: [{ label: "child", startedAt: T0, state: slug === "dead-parent-stale" ? "stale" : "running", id: "a1" }],
+      lastActivityAt: LATER,
+    }),
+    foreignIds: () => [],
+    subAgent: () => undefined,
+    forget: () => {},
+    start: () => {},
+    stop: () => {},
+    tick: () => {},
+  } satisfies Tailer
+  const board = createBoard(project, storage, new Bus(), tailer, "crash-bgwork-boot")
+  try {
+    const snap = await board.snapshot()
+    const running = snap.threads.find((candidate) => candidate.id === "dead-parent")!
+    assert.equal(running.runtime, "exited", "no live pane derives to exited")
+    assert.equal(running.needsYou, true, "the dead parent surfaces instead of being buried by stale child liveness")
+    assert.equal(running.crashed, true, "a running sub-agent on a dead pane cards as a stall, not a bare rest")
+    const stale = snap.threads.find((candidate) => candidate.id === "dead-parent-stale")!
+    assert.equal(stale.needsYou, true, "a dead parent whose child went stale still surfaces")
+    assert.equal(stale.crashed, false, "but a stale child is not live work, so it cards as bare rest")
+  } finally {
+    board.stop()
+  }
+})
+
 test("deriveNeedsYou: manual snooze suppresses every queue reason until its exact deadline", () => {
   const now = Date.parse("2026-07-13T12:00:00.000Z")
   const snoozed = row({ snoozed_until: "2026-07-14T12:00:00.000Z" })

--- a/ui/packages/server/src/board.ts
+++ b/ui/packages/server/src/board.ts
@@ -176,7 +176,13 @@ export function deriveNeedsYou(
   if (tele?.pendingQuestion) return true
   // A top-level turn that is resting only while its own child/Monitor still runs is still in flight,
   // not a human handoff. Once that operation clears, the next board refresh queues the bare rest.
-  if (hasLiveBackgroundWork(tele)) return false
+  // This excuse holds ONLY while the parent pane is alive: a child cannot outlive the process that
+  // spawned it. The tailer already zeroes bgShells on pane death (bgShellViews), but a dead pane's
+  // SUB-AGENTS keep reading "running" until their transcript goes stale — or forever when the child's
+  // output file never resolved (subAgentViews has no paneDead guard). So an EXITED parent still showing
+  // "running" background work is a crash mid-background-work; surface it rather than bury it on stale
+  // child liveness (found 2026-07-21: such a thread silently dangled).
+  if (runtime !== "exited" && hasLiveBackgroundWork(tele)) return false
   if (hasParkedExternalWait(tele, nowMs)) return false
   // A final ```done fence is a CHECKED completion handoff: show its success card in the queue until the
   // human explicitly Archives the thread. Like a question, merely viewing it does not resolve it. The
@@ -298,7 +304,12 @@ function sessionThreadView(
   const state = effectiveSessionState(row, registeredLegacyTerminal)
   const archived = state === "archived"
   const needsYou = archived ? false : deriveNeedsYou(row, tele, runtime, interactionPresence.needsUser, nowMs)
-  const crashed = runtime === "exited" && tele?.turn === "in-flight"
+  // A pane that exited with work still outstanding — a turn in flight, OR a sub-agent still reading
+  // "running" (its parent is gone, so it cannot actually be live) — is a crash/stall, not a clean
+  // handoff, so it cards as "stalled" not a bare "rest". Mirrors deriveNeedsYou's surfacing above. (The
+  // tailer already zeroes bgShells on pane death, so in practice the background-work arm keys on
+  // sub-agents; it flips back to bare rest once the child's transcript goes stale.)
+  const crashed = runtime === "exited" && (tele?.turn === "in-flight" || hasLiveBackgroundWork(tele))
   const snoozedUntil = futureSnooze(row, nowMs)
   const profile = resolveSessionProfile(row, tele)
   const permissionMode = resolveSessionPermission(row, tele)


### PR DESCRIPTION
## What & why

A fray worker that comes to a **clean rest while its own sub-agent is still running** is `turn-idle`, not `in-flight`. If its pane then dies (machine sleep / crash), the sub-agent dies with it — but `subAgentViews` has **no `paneDead` guard** (unlike `bgShellViews`, which already zeroes shells on pane death), so the tailer keeps reporting the child `"running"`.

`deriveNeedsYou` then did `if (hasLiveBackgroundWork(tele)) return false`, which **buried the dead parent from the "needs you" queue** — it resurfaced only once the child's transcript crossed `SUBAGENT_STALE_MS` (~5 min) and flipped to `"stale"`, or **never**, when the child's output file never resolved so it read `"running"` forever. Either way the human lost sight of a dead thread with outstanding work ("it silently stopped surfacing").

Found while investigating a thread that dangled after a laptop sleep.

## Fix

A child cannot outlive the pane that spawned it:
- **`deriveNeedsYou`**: trust "live background work" only while the parent is alive (`runtime !== "exited"`) — an exited parent now falls through and surfaces.
- **`crashed`**: a pane that exited with work still outstanding (turn in-flight OR a sub-agent still reading `"running"`) cards as a **stall**, not a bare "rest".

## Tests
- `deriveNeedsYou` unit regression: running-child + stale-child on an exited parent both surface; a live parent resting on a running child stays held. (Confirmed the running-child assertion **fails** on the pre-fix code.)
- board-snapshot integration test: end-to-end through `createBoard → snapshot`, an exited parent with a running sub-agent enters Queue AND `crashed=true`; with a stale child, surfaces as bare rest (`crashed=false`).
- `board.test.ts` 31/31; server typecheck clean.

## Reviewed
Independent adversarial review (verdict: ship-with-fixes; fixes applied — dropped a bgShell test assertion the tailer can never emit on a dead pane, added the stale-child case). Confirmed correct: the `hasParkedExternalWait` asymmetry (awaiting threads are durably re-woken by the scheduler, so they stay Held) and the guard ordering.

Known, accepted tradeoffs:
- A transient `tmux.isLiveCached` miss (≤900 ms) can flip a live parent to `exited`, briefly surfacing it; self-correcting, and the existing crash-net already does this for in-flight turns.
- `crashed` is computed independent of snooze/held, so a snoozed/awaiting-held exited row with a running sub-agent shows the "stalled" glyph without a queue card (cosmetic, rare, pre-existing pattern).

**Alternative considered:** add the missing `paneDead` guard to `subAgentViews` in the tailer (mirroring `bgShellViews`) so telemetry is truthful at the source. Not taken here because it would make the board's crash detection dead code and drop the "stalled" badge (the board would only ever see a bare rest); this board-side guard keeps the stall signal. Worth revisiting as a follow-up.

https://claude.ai/code/session_01GF2QkwTBcoyzqnqWcMKy1J