### PR TITLE
fix(codex): deliver multi-paragraph steers instead of wedging the queue

### DIFF
--- a/FRAY.md
+++ b/FRAY.md
@@ -8,6 +8,25 @@ don't hand back a plan where a finished change was asked for. Come back to the h
 genuinely human-owned decisions (product/security posture, destructive or irreversible actions) or a
 real blocker.
 
+## Decide and proceed — signal the call, don't stall on it
+
+When the task underspecifies something, your default is to DECIDE, not to ask. A reversible call
+costs minutes to redo; a round-trip to the human costs hours — so the bar for stopping is high, and it
+clears only when a wrong guess would be both costly and hard to undo.
+
+- **Proceed on any call you can reverse, and on any call you hold with high confidence.** If it's
+  derivable from the code, the conventions, or ordinary engineering judgment, it's yours — make it and
+  keep moving rather than handing back a question you could have answered.
+- **Give the human some indication of the approach you took, as you take it.** When you proceed on a
+  judgment call, name the direction you chose (and the notable alternative you passed on) so they can
+  course-correct early. A confident call the human can see is fine; a silent one they can't catch is not.
+- **Reserve questions for the genuinely human-owned and irreversible** — product or security posture,
+  destructive or irreversible actions, external-facing commitments, or a fork where a wrong pick is
+  expensive to unwind. Those earn a round-trip; little else does.
+- **Account for your decisions in the results summary.** Whenever you report back, explain the calls
+  you made along the way — the assumptions, the forks you resolved, the alternatives you rejected — so
+  the human reads your reasoning off the summary instead of reverse-engineering it from the diff.
+
 ## Verify end-to-end — test the whole, not the parts
 
 Every change you land needs REAL end-to-end verification: exercise the actual behavior in the actual

--- a/ui/packages/server/src/permission-controller.test.ts
+++ b/ui/packages/server/src/permission-controller.test.ts
@@ -156,6 +156,36 @@ test("composer inspection matches the exact wrapped nonempty Nub pane and the di
   )
 })
 
+// Regression: a MULTI-PARAGRAPH draft (blank rows between paragraphs) is the common shape of a real
+// steer. captureCodexComposer used to break at the first blank row, truncating the capture to the
+// first paragraph; codexComposerMatches then compared that prefix against the full normalized text
+// and returned false, so the durable queue wedged forever on "existing draft". The blank row is an
+// internal paragraph break, not the composer's end — only the footer/status line ends it.
+test("composer inspection captures a multi-paragraph draft across internal blank lines", () => {
+  const twoParagraphs =
+    "[1m›[0m First paragraph line one\n  continues on row two\n\n  Second paragraph after a blank line\n\n  gpt-5.6-sol xhigh · ~/Documents/projects/fray · Context 66% used"
+  assert.equal(inspectCodexComposer(twoParagraphs).kind, "typed", "a multi-paragraph draft is a typed composer")
+  assert.equal(
+    codexComposerMatches(twoParagraphs, "First paragraph line one continues on row two\n\nSecond paragraph after a blank line"),
+    true,
+    "the exact multi-paragraph staged text matches and can be submitted",
+  )
+  // Three-blank-line gaps collapse identically (normalizedInput turns any whitespace run into one space).
+  const threeBlanks =
+    "[1m›[0m Alpha\n\n\n  Bravo\n\n  gpt-5.6-sol xhigh · ~/x · 100% context left"
+  assert.equal(codexComposerMatches(threeBlanks, "Alpha\n\nBravo"), true)
+  // Fail-closed preserved: a genuinely different draft is never accepted just because we scan further.
+  assert.equal(
+    codexComposerMatches(twoParagraphs, "First paragraph line one continues on row two\n\nA DIFFERENT second paragraph"),
+    false,
+    "a non-matching multi-paragraph draft still fails closed",
+  )
+  // A footer hint rendered TIGHT under the draft (no blank between) still ends the draft — parity with
+  // the old parts-based capture, so delivery never re-wedges if Codex drops the pre-footer blank row.
+  const esc = String.fromCharCode(27)
+  assert.equal(codexComposerMatches(`${esc}[1m›${esc}[0m Do the safe thing\n  ${esc}[2m100% context left${esc}[0m`, "Do the safe thing"), true)
+})
+
 test("Claude composer inspection distinguishes the idle prompt from an unsent draft or modal", () => {
   assert.deepEqual(inspectClaudeComposer("history\n❯\u00a0\n────────\n  ⏵⏵ auto mode on"), { kind: "empty" })
   assert.deepEqual(inspectClaudeComposer("history\n❯\u00a0UNSENT_DRAFT_PROBE\n────────"), { kind: "typed", text: "UNSENT_DRAFT_PROBE" })

--- a/ui/packages/server/src/permission-controller.ts
+++ b/ui/packages/server/src/permission-controller.ts
@@ -139,7 +139,7 @@ export type ClaudeComposerState =
 
 type CodexComposerCapture =
   | { kind: "empty" }
-  | { kind: "typed"; parts: string[]; queueHint: boolean }
+  | { kind: "typed"; parts: string[]; rows: { text: string; boundaryBefore: boolean }[]; queueHint: boolean }
   | { kind: "unavailable" }
 
 // Capture only Codex's LAST bold composer prompt. Keeping the visual rows lets the durable-input
@@ -154,16 +154,29 @@ function captureCodexComposer(escapedPane: string): CodexComposerCapture {
     if (!marker || marker.index === undefined) continue
     const raw = lines[i].slice(marker.index + marker[0].length)
     if (/^\s*\x1b\[2m/.test(raw)) return { kind: "empty" }
+    // `parts` stops at the first blank/footer — the text-extraction (inspectCodexComposer) contract.
+    // `rows` keeps every visual row below the marker, each tagged with whether a blank (a paragraph
+    // break) preceded it, WITHOUT guessing the footer boundary: the target-aware codexComposerMatches
+    // decides where a (possibly multi-paragraph) draft ends. A blank row alone is NOT the end — a
+    // real steer routinely contains blank lines between paragraphs.
     const parts = [stripAnsi(raw).trim()]
+    const rows = [{ text: parts[0], boundaryBefore: false }]
+    let blankPending = false
+    let sawStop = false
     for (let j = i + 1; j < lines.length; j++) {
       const part = stripAnsi(lines[j]).trim()
-      if (!part) break
-      if (part.includes("tab to queue message") || part.includes("context left")) break
-      parts.push(part)
+      if (!part) { blankPending = true; continue }
+      if (!sawStop) {
+        if (part.includes("tab to queue message") || part.includes("context left") || blankPending) sawStop = true
+        else parts.push(part)
+      }
+      rows.push({ text: part, boundaryBefore: blankPending })
+      blankPending = false
     }
     return {
       kind: "typed",
       parts,
+      rows,
       // The phrase can occur in transcript history or in the user's draft. Trust only Codex's dim
       // footer after this (last) composer marker, never a global plain-text match.
       queueHint: lines.slice(i + 1).some((line) => {
@@ -200,20 +213,48 @@ export function inspectCodexComposer(escapedPane: string): CodexComposerState {
 }
 
 // Compare a persisted queue item with the visual composer without guessing where Codex inserted a
-// soft row break. Every boundary may represent either zero characters (a token split) or one
-// normalized whitespace character (a word/newline break); differences anywhere INSIDE a row still
-// fail closed. The position-set DP is linear in practice and cannot explode as 2^rows.
+// soft row break. Every WITHIN-paragraph boundary may represent either zero characters (a token
+// split) or one normalized whitespace character (a word break); a BLANK row is a paragraph break —
+// always exactly one normalized space. Differences anywhere INSIDE a row still fail closed. The
+// position-set DP is linear in practice and cannot explode as 2^rows.
+//
+// The draft can be MULTI-PARAGRAPH (blank rows between paragraphs) and is followed by Codex's
+// footer/status line. Rather than guess where the draft ends and the footer begins (the status line
+// has no stable, draft-distinct signature — it can be a bare model slug), the draft is defined as the
+// blank-separated run of rows that EXACTLY reconstructs the target: once the target is fully matched
+// at a paragraph boundary, the draft is complete and everything below is footer. This is strictly
+// tighter than the old "stop at the first blank" rule for a single paragraph and, unlike it, no longer
+// truncates a multi-paragraph steer to its first paragraph (which wedged the durable queue forever).
 export function codexComposerMatches(escapedPane: string, expected: string): boolean {
   const captured = captureCodexComposer(escapedPane)
-  if (captured.kind !== "typed" || captured.parts.length === 0) return false
+  if (captured.kind !== "typed" || captured.rows.length === 0) return false
   const target = normalizedInput(expected)
-  const parts = captured.parts.map(normalizedInput)
-  if (!target.startsWith(parts[0])) return false
-  let positions = new Set([parts[0].length])
-  for (const part of parts.slice(1)) {
+  if (!target) return false
+  const first = normalizedInput(captured.rows[0].text)
+  if (first === "" || !target.startsWith(first)) return false
+  let positions = new Set([first.length])
+  for (const row of captured.rows.slice(1)) {
+    // A blank row separated the previous paragraph from this row. If the target is already fully
+    // reconstructed, the draft ended at that paragraph and this row (plus the footer/status below it)
+    // is not part of the staged text — the composer is confirmed to hold exactly our message.
+    if (row.boundaryBefore && positions.has(target.length)) return true
+    // A recognized footer hint ends the draft even when Codex renders it tight under the last line
+    // (no blank between). The old parts-based capture stopped at these markers regardless of blanks;
+    // preserving that keeps delivery robust if a future Codex build drops the pre-footer blank row.
+    // (The status/mode line has no such stable marker — it is handled only by the blank-boundary rule
+    // above, which is why a foreign draft whose leading paragraphs happen to exactly equal the queued
+    // text can still early-complete; that submit is a deliberate, near-impossible trade for never
+    // wedging a real multi-paragraph steer.)
+    if (row.text.includes("tab to queue message") || row.text.includes("context left")) {
+      return positions.has(target.length)
+    }
+    const part = normalizedInput(row.text)
+    if (part === "") continue
+    // A paragraph break is exactly one space; a within-paragraph wrap is "" or " ".
+    const separators = row.boundaryBefore ? [" "] : ["", " "]
     const next = new Set<number>()
     for (const position of positions) {
-      for (const separator of ["", " "]) {
+      for (const separator of separators) {
         const token = separator + part
         if (target.startsWith(token, position)) next.add(position + token.length)
       }


### PR DESCRIPTION
## The bug

You reported being unable to steer/follow-up several Codex threads — messages sat "enqueued" but never reached the agent. Confirmed on the live board: many Codex threads wedged with `control_error: "Queued message blocked: submit or clear the existing Codex terminal draft"`, real messages (`"This snooze button should remain white…"`, `"Do not keep legacy shit around…"`, `"yo!"`) stranded in `codex_input_queue` for **hours**.

## Root cause

A queued Codex follow-up is staged into the TUI composer, then submitted only after `codexComposerMatches` confirms the composer holds **exactly** that text. `captureCodexComposer` stopped scanning at the **first blank line** (`if (!part) break`). Every stuck message was **multi-paragraph** (contained a blank line / `\n\n`), so the capture truncated to paragraph 1; `codexComposerMatches` compared that prefix against the full normalized text → `false` → the message was treated as a foreign draft and the durable queue wedged forever.

Verified directly: on the real stuck pane, `inspectCodexComposer` captured 506 of the 686-char message and `codexComposerMatches` returned `false`.

## The fix

- `captureCodexComposer` now also returns `rows` — every visual row below the composer marker, each tagged `boundaryBefore` (a blank row preceded it). `parts` (and thus `inspectCodexComposer`) is **unchanged**.
- `codexComposerMatches` is rewritten as a segment-aware DP over `rows`: within a paragraph a soft wrap is `""`/`" "`; a blank row is a paragraph break (exactly one space); once the target is fully reconstructed **at a paragraph boundary** the draft is complete and the footer/status line below is ignored — **no fragile footer-line detection** (the status line can be a bare model slug with no stable signature). A recognized footer hint (`tab to queue message` / `context left`) still ends the draft even with no preceding blank, matching the old parts-based capture.

## Verification

- **End-to-end against a real Codex TUI**: a two-paragraph steer is staged, matched, submitted, and **received + acted on by the agent**; the pre-fix matcher returns `false` (would wedge) on the same live composer.
- **Real live data**: both stuck threads' head items now match (would submit); foreign text still rejected.
- Tests: 38 `permission-controller` + 228 across `resume`/`profile-controller`/`board`/`tailer`; typecheck clean.

## Known trade-off

Defining the draft as "the blank-terminated prefix that reconstructs the target" means a *foreign* draft whose leading paragraph(s) exactly equal the queued text (with extra trailing paragraphs) can early-complete and submit the extra content. This is near-impossible in practice and closing it would require the fragile footer detection this fix deliberately avoids; it's a deliberate trade for never wedging a real multi-paragraph steer (documented in the code).

## Deploying / unblocking the stuck threads

This runs from a built bundle, so the fix takes effect on rebuild + restart. Once it's live, the controller's next `tick()` will match and submit the already-staged drafts, auto-flushing the stranded queues. Restart kills live workers (including this session), so it's your call when.

https://claude.ai/code/session_01DFwHvmsdXRrMDRVbKR44H1