### PR TITLE
Reap orphaned worker aux processes (leaked verification browsers + MCP/dev servers)

### DIFF
--- a/ui/packages/server/src/context.ts
+++ b/ui/packages/server/src/context.ts
@@ -35,6 +35,7 @@ import {
   adoptionRuntimeBinding,
   reconcileAdoptionClaims,
 } from "./adoption-recovery.ts"
+import { startOrphanReaper } from "./orphan-reaper.ts"
 import {
   createRetryableCleanup,
   createShutdownBarrier,
@@ -375,6 +376,17 @@ function createContextUnchecked(opts: ContextOptions, resources: PartialContextR
   }, ADOPTION_RECONCILE_INTERVAL_MS)
   adoptionReconcileTimer.unref?.()
   contextUnsubscribers.push(() => clearInterval(adoptionReconcileTimer))
+
+  // Reap this machine's leaked worker aux — verification browsers (agent-browser/chrome-devtools/
+  // puppeteer) and MCP/dev servers that daemonized out of a stopped worker's tmux tree, so nothing
+  // else ever collects them. A sweep on startup clears accumulated leaks; the interval catches new
+  // orphans (a stopped/crashed thread's browsers) within a bounded window. Reaps ONLY processes
+  // whose FRAY_UI_THREAD slug has no live claude/codex root; never a session/tmux/self process.
+  // FRAY_ORPHAN_REAPER_OFF disables it for disposable adhoc/test stacks (mirrors FRAY_WAKERS_OFF) so a
+  // throwaway instance never reaps the real machine's processes.
+  if (!process.env.FRAY_ORPHAN_REAPER_OFF) {
+    contextUnsubscribers.push(startOrphanReaper({ log: (m) => console.log(`[fray-ui] ${m}`) }))
+  }
   reconcileSessions(storage)
   opts.startup?.afterPhase?.("subscriptions")
 

--- a/ui/packages/server/src/orphan-reaper.test.ts
+++ b/ui/packages/server/src/orphan-reaper.test.ts
@@ -1,0 +1,253 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+import {
+  firstTokenBasename,
+  isSessionRoot,
+  isTmuxServer,
+  decideOrphans,
+  selfAndAncestors,
+  subtreeKillOrder,
+  parseEtimeMs,
+  enumerateProcs,
+  reapSubtrees,
+  sweepOrphansOnce,
+  type ProcRow,
+  type Exec,
+} from "./orphan-reaper.ts"
+
+const OLD = 10 * 60_000 // comfortably past the age guard
+const ORPHAN_GUARD = 120_000
+
+function row(p: Partial<ProcRow> & { pid: number }): ProcRow {
+  return { ppid: 1, ageMs: OLD, command: "node x", slug: null, ...p }
+}
+
+test("firstTokenBasename strips path and args", () => {
+  assert.equal(firstTokenBasename("/usr/bin/node --foo bar"), "node")
+  assert.equal(firstTokenBasename("claude --session-id abc"), "claude")
+  assert.equal(firstTokenBasename("  /a/b/Google Chrome for Testing --x"), "Google")
+  assert.equal(firstTokenBasename(""), "")
+})
+
+test("isSessionRoot: claude/codex binary or --session-id anywhere", () => {
+  assert.ok(isSessionRoot("claude --session-id abc"))
+  assert.ok(isSessionRoot("/opt/claude"))
+  assert.ok(isSessionRoot("codex --cd /x -m gpt"))
+  assert.ok(isSessionRoot("node /path/cli.js --session-id zzz")) // node-launched agent
+  assert.ok(!isSessionRoot("node /path/chrome-devtools-mcp"))
+  assert.ok(!isSessionRoot("Google Chrome for Testing --remote-debugging-port=0"))
+})
+
+test("isTmuxServer matches only the tmux binary", () => {
+  assert.ok(isTmuxServer("tmux -L fray-repo-x new-session -d"))
+  assert.ok(!isTmuxServer("node tmux-thing"))
+})
+
+test("decideOrphans: reap aux whose slug has no live root; keep everything protected", () => {
+  const rows: ProcRow[] = [
+    row({ pid: 100, command: "claude --session-id A", slug: "alpha" }), // live root alpha
+    row({ pid: 101, command: "node chrome-devtools-mcp", slug: "alpha" }), // aux of LIVE alpha → keep
+    row({ pid: 200, command: "Google Chrome for Testing --remote-debugging-port=0", slug: "beta" }), // aux, dead beta → REAP
+    row({ pid: 201, command: "node --watch server.js", slug: "beta" }), // aux, dead beta → REAP
+    row({ pid: 300, command: "codex --cd /x", slug: "gamma" }), // a session root with no aux; dead-ish but NEVER reaped
+    row({ pid: 400, command: "tmux -L fray-repo-x new-session", slug: "delta" }), // tmux tagged, dead → keep
+  ]
+  const { reap, liveSlugs } = decideOrphans(rows, { minAgeMs: ORPHAN_GUARD, protectedPids: new Set() })
+  assert.deepEqual([...reap].sort((a, b) => a - b), [200, 201])
+  assert.deepEqual([...liveSlugs].sort(), ["alpha", "gamma"])
+})
+
+test("decideOrphans: age guard spares just-spawned aux", () => {
+  const rows: ProcRow[] = [
+    row({ pid: 200, ageMs: 5_000, command: "Google Chrome for Testing --x", slug: "beta" }), // fresh → keep
+    row({ pid: 201, ageMs: OLD, command: "Google Chrome for Testing --x", slug: "beta" }), // old → reap
+  ]
+  const { reap } = decideOrphans(rows, { minAgeMs: ORPHAN_GUARD, protectedPids: new Set() })
+  assert.deepEqual(reap, [201])
+})
+
+test("decideOrphans: protected pids (self/ancestors) are never reaped", () => {
+  const rows: ProcRow[] = [row({ pid: 200, command: "node orphan.js", slug: "beta" })]
+  const { reap } = decideOrphans(rows, { minAgeMs: ORPHAN_GUARD, protectedPids: new Set([200]) })
+  assert.deepEqual(reap, [])
+})
+
+test("decideOrphans: a dead slug shared with a still-live root elsewhere is kept (never false-kill)", () => {
+  // Same slug string owned by a live root — its aux must survive even if another proc has it too.
+  const rows: ProcRow[] = [
+    row({ pid: 100, command: "claude --session-id X", slug: "shared" }),
+    row({ pid: 101, command: "node agent-browser", slug: "shared" }),
+  ]
+  const { reap } = decideOrphans(rows, { minAgeMs: ORPHAN_GUARD, protectedPids: new Set() })
+  assert.deepEqual(reap, [])
+})
+
+test("selfAndAncestors walks the parent chain", () => {
+  const rows: ProcRow[] = [
+    row({ pid: 10, ppid: 1 }),
+    row({ pid: 20, ppid: 10 }),
+    row({ pid: 30, ppid: 20 }),
+  ]
+  // includes the terminal ppid (1); harmless — protecting a pid only means "never reap it"
+  assert.deepEqual([...selfAndAncestors(rows, 30)].sort((a, b) => a - b), [1, 10, 20, 30])
+})
+
+test("selfAndAncestors tolerates cycles", () => {
+  const rows: ProcRow[] = [row({ pid: 10, ppid: 20 }), row({ pid: 20, ppid: 10 })]
+  const set = selfAndAncestors(rows, 10)
+  assert.ok(set.has(10) && set.has(20))
+})
+
+test("subtreeKillOrder: leaves before parents, drops kept procs", () => {
+  const rows: ProcRow[] = [
+    row({ pid: 100, ppid: 1, command: "node mcp", slug: "beta" }),
+    row({ pid: 110, ppid: 100, command: "Chrome main", slug: "beta" }),
+    row({ pid: 120, ppid: 110, command: "Chrome renderer", slug: "beta" }),
+    row({ pid: 130, ppid: 100, command: "claude --session-id keepme", slug: "gamma" }), // must be dropped
+  ]
+  const keep = (r: ProcRow) => isSessionRoot(r.command)
+  const order = subtreeKillOrder([100], rows, keep)
+  assert.ok(!order.includes(130), "live session root nested under a target is never killed")
+  // deepest first: 120 before 110 before 100
+  assert.ok(order.indexOf(120) < order.indexOf(110))
+  assert.ok(order.indexOf(110) < order.indexOf(100))
+  assert.deepEqual([...order].sort((a, b) => a - b), [100, 110, 120])
+})
+
+test("parseEtimeMs handles all ps formats", () => {
+  assert.equal(parseEtimeMs("05"), 5_000)
+  assert.equal(parseEtimeMs("01:30"), 90_000)
+  assert.equal(parseEtimeMs("02:00:00"), 2 * 3600_000)
+  assert.equal(parseEtimeMs("3-04:00:00"), (3 * 24 + 4) * 3600_000)
+  assert.equal(parseEtimeMs("garbage"), 0)
+  assert.equal(parseEtimeMs(""), 0)
+})
+
+// ---- enumeration + reap with a fake `ps` ----------------------------------------------------------
+
+function fakePs(base: string, env: string): Exec {
+  return (file, args) => {
+    assert.equal(file, "ps")
+    if (args.includes("-Eww")) return env
+    return base
+  }
+}
+
+test("enumerateProcs joins argv pass with env pass, slug from the ENV segment only", () => {
+  const base = [
+    "  100        1 10:00 claude --session-id A",
+    "  200      100 09:00 Google Chrome for Testing --remote-debugging-port=0",
+    // tmux carries a FRAY_UI_THREAD literal in ARGV (the `-e` flag); its OWN env has a different one
+    "  400        1 20:00 tmux -L fray-repo-x new-session -d -e FRAY_UI_THREAD=argvslug",
+  ].join("\n")
+  const env = [
+    "100 claude --session-id A FRAY_UI_THREAD=alpha",
+    "200 Google Chrome for Testing --remote-debugging-port=0 FRAY_UI_THREAD=alpha",
+    "400 tmux -L fray-repo-x new-session -d -e FRAY_UI_THREAD=argvslug HOME=/x FRAY_UI_THREAD=envslug",
+  ].join("\n")
+  const procs = enumerateProcs(fakePs(base, env))
+  const byPid = new Map(procs.map((p) => [p.pid, p]))
+  assert.equal(byPid.get(100)!.slug, "alpha")
+  assert.equal(byPid.get(200)!.slug, "alpha")
+  assert.equal(byPid.get(400)!.ppid, 1)
+  assert.equal(byPid.get(200)!.ageMs, 9 * 60_000)
+  // the ENV slug wins over the argv `-e FRAY_UI_THREAD=argvslug` literal
+  assert.equal(byPid.get(400)!.slug, "envslug")
+})
+
+test("enumerateProcs: a FRAY_UI_THREAD literal in a ROOT's argv never overrides its real env slug", () => {
+  // Reproduces the critical mis-attribution: a worker whose task text pasted `FRAY_UI_THREAD=other`
+  // into its argv. Ownership must come from ENV, or the root's real slug would be lost from `live`.
+  const base = ["  100 1 10:00 claude --session-id A pasted:FRAY_UI_THREAD=other-slug"].join("\n")
+  const env = ["100 claude --session-id A pasted:FRAY_UI_THREAD=other-slug FRAY_UI_THREAD=realroot"].join("\n")
+  const procs = enumerateProcs(fakePs(base, env))
+  assert.equal(procs[0]!.slug, "realroot")
+})
+
+test("enumerateProcs: reads the slug across a multiline env value and re-merges false splits", () => {
+  const base = ["  100 1 10:00 node dev.js"].join("\n")
+  // env contains a PEM key with newlines, AND a line that starts with a digit+space (a false record
+  // boundary that must be re-merged), with the real slug appearing AFTER all of it.
+  const env = [
+    "100 node dev.js KEY=-----BEGIN-----",
+    "500 not-a-real-record continues the KEY value",
+    "-----END----- FRAY_UI_THREAD=realslug",
+  ].join("\n")
+  const procs = enumerateProcs(fakePs(base, env))
+  assert.equal(procs[0]!.slug, "realslug")
+})
+
+test("enumerateProcs: a pid whose pass-2 argv does not match pass-1 (reuse) yields no slug (fail-safe)", () => {
+  const base = ["  100 1 10:00 node real-argv"].join("\n")
+  const env = ["100 node DIFFERENT-argv FRAY_UI_THREAD=whatever"].join("\n") // marker mismatch
+  const procs = enumerateProcs(fakePs(base, env))
+  assert.equal(procs[0]!.slug, null)
+})
+
+test("enumerateProcs fails closed when the env pass throws", () => {
+  const exec: Exec = (_file, args) => {
+    if (args.includes("-Eww")) throw new Error("boom")
+    return "  100 1 10:00 node x"
+  }
+  const procs = enumerateProcs(exec)
+  assert.equal(procs.length, 1)
+  assert.equal(procs[0]!.slug, null) // no slug → never reaped
+})
+
+test("sweepOrphansOnce end-to-end with fakes: reaps dead-slug Chrome, spares live + self", () => {
+  const base = [
+    "  100     1 10:00 claude --session-id A",
+    "  101   100 10:00 node chrome-devtools-mcp",
+    "  200     1 10:00 Google Chrome for Testing --remote-debugging-port=0",
+    "  201   200 10:00 Google Chrome Helper (Renderer)",
+    "  999     1 10:00 node server.js", // the reaper's own process (self)
+  ].join("\n")
+  const env = [
+    "100 claude --session-id A FRAY_UI_THREAD=alpha",
+    "101 node chrome-devtools-mcp FRAY_UI_THREAD=alpha",
+    "200 Google Chrome for Testing --remote-debugging-port=0 FRAY_UI_THREAD=beta",
+    "201 Google Chrome Helper (Renderer) FRAY_UI_THREAD=beta",
+    "999 node server.js FRAY_UI_THREAD=beta", // even if tagged beta, it is self → protected
+  ].join("\n")
+  const killed: number[] = []
+  const res = sweepOrphansOnce({
+    exec: fakePs(base, env),
+    kill: (pid) => killed.push(pid),
+    selfPid: 999,
+    minAgeMs: 120_000,
+  })
+  assert.deepEqual(killed.sort((a, b) => a - b), [200, 201]) // beta subtree only
+  assert.ok(!killed.includes(999), "self never reaped even when tagged with a dead slug")
+  assert.ok(!killed.includes(100) && !killed.includes(101), "live alpha kept")
+  assert.equal(res.reaped, 2)
+  assert.deepEqual(res.deadSlugs, ["beta"])
+  assert.deepEqual(res.liveSlugs, ["alpha"])
+})
+
+test("sweepOrphansOnce: a live root whose argv holds a stray FRAY_UI_THREAD literal never gets its aux reaped", () => {
+  // The critical false-kill regression: root's REAL slug is `realthread` (env); its argv also contains
+  // a pasted `FRAY_UI_THREAD=spoofed`. If ownership were read from argv, `realthread` would look dead
+  // and the live aux (101) would be reaped mid-verification. It must not be.
+  const base = [
+    "  100 1 10:00 claude --session-id A note:FRAY_UI_THREAD=spoofed",
+    "  101 100 10:00 node chrome-devtools-mcp",
+  ].join("\n")
+  const env = [
+    "100 claude --session-id A note:FRAY_UI_THREAD=spoofed FRAY_UI_THREAD=realthread",
+    "101 node chrome-devtools-mcp FRAY_UI_THREAD=realthread",
+  ].join("\n")
+  const killed: number[] = []
+  const res = sweepOrphansOnce({ exec: fakePs(base, env), kill: (p) => killed.push(p), selfPid: 999, minAgeMs: 120_000 })
+  assert.deepEqual(killed, [], "no aux reaped — realthread is live via its root")
+  assert.deepEqual(res.liveSlugs, ["realthread"])
+})
+
+test("reapSubtrees never signals a protected or live-slug pid even if seeded", () => {
+  const rows: ProcRow[] = [
+    row({ pid: 200, ppid: 1, command: "node x", slug: "beta" }),
+    row({ pid: 201, ppid: 200, command: "claude --session-id L", slug: "live" }),
+  ]
+  const killed: number[] = []
+  reapSubtrees([200], rows, new Set(), new Set(["live"]), (p) => killed.push(p))
+  assert.deepEqual(killed, [200]) // 201 is a session root → dropped
+})

--- a/ui/packages/server/src/orphan-reaper.ts
+++ b/ui/packages/server/src/orphan-reaper.ts
@@ -1,0 +1,342 @@
+// Orphan process reaper — fray spawns a worker per thread (a detached `claude`/`codex` in a tmux
+// pane) and each worker spawns auxiliary processes for its task: MCP servers, dev/watch servers, and
+// verification browsers (chrome-devtools-mcp, agent-browser, puppeteer). `tmux kill-session` signals
+// only the pane's process group, so anything that daemonized out of that group (agent-browser
+// double-forks its Chrome to launchd; a `node --watch` reparents on crash) SURVIVES the stop and
+// leaks — permanently, since nothing else collects it. Over days this accretes GBs of orphaned
+// Chrome/node whose owning thread is long gone. This module reaps exactly those.
+//
+// Ownership is read from the env marker every worker carries: FRAY_UI_THREAD=<slug> (set at spawn in
+// dispatch.ts/resume.ts), inherited by everything the worker spawns. A slug is LIVE iff a live
+// `claude`/`codex` session process still carries it — a worker's only OS-level agent process is its
+// session root (Agent sub-agents are in-process), so this is exact and socket-agnostic (it protects
+// a live adhoc-stack's workers automatically, since their roots are alive on the machine).
+//
+// SAFETY — the reaper only ever kills an AUXILIARY process whose slug is live NOWHERE. It never
+// touches: a session root (`claude`/`codex`, or anything bearing `--session-id`), a tmux server
+// (they carry the first thread's slug in env but are shared infrastructure), the reaper's own
+// process or any ancestor (so it can never kill the server it runs in — which is untagged anyway,
+// being user-spawned rather than worker-spawned), or any process whose slug is currently live. Every
+// enumeration failure fails CLOSED (reap nothing). An age guard skips just-spawned processes.
+
+import { execFileSync } from "node:child_process"
+
+export const ORPHAN_REAP_INTERVAL_MS = 60_000
+export const ORPHAN_MIN_AGE_MS = 120_000
+
+const SLUG_RE = /FRAY_UI_THREAD=([A-Za-z0-9._-]+)/
+
+export interface ProcRow {
+  pid: number
+  ppid: number
+  ageMs: number
+  /** argv only (no env), from `ps -o command=` */
+  command: string
+  /** FRAY_UI_THREAD read from the process ENVIRONMENT, or null when untagged/unreadable */
+  slug: string | null
+}
+
+// ---- Pure classification --------------------------------------------------------------------------
+
+export function firstTokenBasename(command: string): string {
+  const first = command.trimStart().split(/\s+/, 1)[0] ?? ""
+  const slash = first.lastIndexOf("/")
+  return slash >= 0 ? first.slice(slash + 1) : first
+}
+
+/** A worker's session process — the only thing that DEFINES a slug as live, and never a reap target. */
+export function isSessionRoot(command: string): boolean {
+  const base = firstTokenBasename(command)
+  if (base === "claude" || base === "codex") return true
+  // A node-launched agent CLI still carries --session-id; belt-and-suspenders so a session process
+  // is never mistaken for reapable aux regardless of how it was invoked.
+  return /(?:^|\s)--session-id(?:\s|=)/.test(command)
+}
+
+/** tmux servers inherit the first thread's FRAY_UI_THREAD in env, but are shared infrastructure. */
+export function isTmuxServer(command: string): boolean {
+  return firstTokenBasename(command) === "tmux"
+}
+
+// ---- Pure decisions -------------------------------------------------------------------------------
+
+export interface ReapDecision {
+  /** aux "roots" to reap (each expanded to its subtree by the caller) */
+  reap: number[]
+  liveSlugs: string[]
+}
+
+function reapable(row: ProcRow, live: Set<string>, protectedPids: ReadonlySet<number>): boolean {
+  if (!row.slug) return false // untagged → not ours to touch
+  if (live.has(row.slug)) return false // owner still alive
+  if (isSessionRoot(row.command)) return false // never a session process
+  if (isTmuxServer(row.command)) return false // never shared tmux infra
+  if (protectedPids.has(row.pid)) return false // never self / ancestors
+  return true
+}
+
+/** Periodic sweep decision: reap tagged aux whose slug is live nowhere and which cleared the age guard. */
+export function decideOrphans(
+  rows: readonly ProcRow[],
+  opts: { minAgeMs: number; protectedPids: ReadonlySet<number> },
+): ReapDecision {
+  const live = new Set<string>()
+  for (const r of rows) if (r.slug && isSessionRoot(r.command)) live.add(r.slug)
+
+  const reap: number[] = []
+  for (const r of rows) {
+    if (!reapable(r, live, opts.protectedPids)) continue
+    if (r.ageMs < opts.minAgeMs) continue // just-spawned; give the owner time to appear
+    reap.push(r.pid)
+  }
+  return { reap, liveSlugs: [...live] }
+}
+
+/** self + every ancestor, so the reaper can never kill the server process it runs inside. */
+export function selfAndAncestors(rows: readonly ProcRow[], selfPid: number): Set<number> {
+  const parentOf = new Map<number, number>()
+  for (const r of rows) parentOf.set(r.pid, r.ppid)
+  const set = new Set<number>([selfPid])
+  let cur = selfPid
+  for (let guard = 0; guard < 10_000; guard++) {
+    const pp = parentOf.get(cur)
+    if (pp === undefined || pp <= 0 || set.has(pp)) break
+    set.add(pp)
+    cur = pp
+  }
+  return set
+}
+
+/**
+ * Expand seed pids to their full descendant subtrees, deepest-first, dropping any pid that must not
+ * die (protected / session root / tmux / live-slug). Leaves-first order guarantees a parent is never
+ * killed before its children, so no child is re-orphaned to launchd mid-reap.
+ */
+export function subtreeKillOrder(
+  seed: readonly number[],
+  rows: readonly ProcRow[],
+  keep: (row: ProcRow) => boolean,
+): number[] {
+  const byPid = new Map<number, ProcRow>()
+  const childrenOf = new Map<number, number[]>()
+  for (const r of rows) {
+    byPid.set(r.pid, r)
+    const list = childrenOf.get(r.ppid) ?? []
+    list.push(r.pid)
+    childrenOf.set(r.ppid, list)
+  }
+  const set = new Set<number>()
+  const stack = [...seed]
+  while (stack.length) {
+    const pid = stack.pop()!
+    if (set.has(pid)) continue
+    const row = byPid.get(pid)
+    if (row && keep(row)) continue // a protected/live proc nested under a target is never killed
+    set.add(pid)
+    for (const c of childrenOf.get(pid) ?? []) stack.push(c)
+  }
+  const depth = (pid: number): number => {
+    let d = 0
+    let cur = pid
+    for (let guard = 0; guard < 10_000; guard++) {
+      const pp = byPid.get(cur)?.ppid
+      if (pp === undefined || !set.has(pp)) break
+      d++
+      cur = pp
+    }
+    return d
+  }
+  return [...set].sort((a, b) => depth(b) - depth(a))
+}
+
+// ---- etime parsing --------------------------------------------------------------------------------
+
+/** ps etime → ms. Accepts `SS`, `MM:SS`, `HH:MM:SS`, `DD-HH:MM:SS`. Unparseable → 0 (fails the guard). */
+export function parseEtimeMs(etime: string): number {
+  const trimmed = etime.trim()
+  if (!trimmed) return 0
+  let days = 0
+  let rest = trimmed
+  const dash = rest.indexOf("-")
+  if (dash >= 0) {
+    days = Number(rest.slice(0, dash))
+    rest = rest.slice(dash + 1)
+  }
+  const parts = rest.split(":").map((p) => Number(p))
+  if (parts.some((n) => !Number.isFinite(n))) return 0
+  let h = 0
+  let m = 0
+  let s = 0
+  if (parts.length === 3) [h, m, s] = parts
+  else if (parts.length === 2) [m, s] = parts
+  else if (parts.length === 1) [s] = parts
+  else return 0
+  return (((days * 24 + h) * 60 + m) * 60 + s) * 1000
+}
+
+// ---- Process enumeration (impure, injectable) -----------------------------------------------------
+
+export type Exec = (file: string, args: string[]) => string
+
+const defaultExec: Exec = (file, args) =>
+  execFileSync(file, args, { encoding: "utf8", maxBuffer: 16 * 1024 * 1024, timeout: 10_000 })
+
+/**
+ * Two `ps` passes joined by pid: pass 1 (`-o command=`, argv only) for pid/ppid/etime/command; pass 2
+ * (`-Eww`, env appended) to read the FRAY_UI_THREAD slug FROM THE ENV SEGMENT ONLY (the pass-1 argv
+ * is stripped off first). Reading the slug from env — never argv — is what stops a literal
+ * `FRAY_UI_THREAD=x` inside a process's argv (pasted task text, a tmux `-e` flag, a grep) from
+ * spoofing ownership and mis-attributing a live thread's slug.
+ *
+ * Deliberately TWO passes, not one `-Eww` pass storing the whole line: a process's full environment
+ * (which `ps -E` appends) contains its secrets — API keys, tokens, private keys. The retained
+ * `command` is argv-only, and the env-bearing text never escapes this function beyond the slug regex,
+ * so secrets can't leak into a log or error. The cost is a negligible pid-reuse race (a pid reassigned
+ * between the two sub-ms `ps` calls fails the `${pid} ${argv}` marker match → no slug → not reaped, so
+ * the race is fail-safe, never a false kill).
+ *
+ * Env VALUES can contain newlines (PEM keys, JSON service accounts), so a pass-2 record spans several
+ * physical lines; records are delimited by their `<pid> <argv>` marker and false splits re-merged,
+ * rather than split on raw newlines. Returns only same-user, parseable rows. macOS `ps -E` cannot read
+ * the env of SIP platform binaries like /bin/sleep, but every process a worker actually leaks — node
+ * MCP/dev servers and Chrome browsers — is a non-system binary whose env IS readable (verified in the
+ * harness). A total env-pass failure fails closed (every slug null → nothing reapable), and since a
+ * root and its aux share one env read there is no partial mode that hides a live root while surfacing
+ * its aux.
+ */
+export function enumerateProcs(exec: Exec = defaultExec): ProcRow[] {
+  // `-ww` (both passes) disables ps's column truncation so pass-1 argv is the FULL argv — required
+  // for the prefix strip below to leave a clean env segment.
+  const base = exec("ps", ["-axww", "-o", "pid=,ppid=,etime=,command="])
+  const rows: ProcRow[] = []
+  const byPid = new Map<number, ProcRow>()
+  const pids: number[] = []
+  for (const line of base.split("\n")) {
+    const m = line.match(/^\s*(\d+)\s+(\d+)\s+(\S+)\s+(.*)$/)
+    if (!m) continue
+    const pid = Number(m[1])
+    const ppid = Number(m[2])
+    if (!Number.isInteger(pid) || pid <= 0) continue
+    const row: ProcRow = { pid, ppid, ageMs: parseEtimeMs(m[3]!), command: m[4]!, slug: null }
+    rows.push(row)
+    byPid.set(pid, row)
+    pids.push(pid)
+  }
+  if (!pids.length) return rows
+
+  // Pass 2: `-Eww -o pid=,command=` appends the full ENVIRONMENT after argv. Two subtleties:
+  //  (a) the slug MUST come from the env, not argv — a process whose argv contains a literal
+  //      `FRAY_UI_THREAD=x` (pasted task text, a grep, a tmux `-e` flag) would otherwise spoof
+  //      ownership. So strip the known pass-1 argv prefix and read the slug only from what follows.
+  //  (b) an env VALUE can contain newlines (PEM keys, JSON), so a record spans multiple physical
+  //      lines. Split on record starts (`<pid> <argv>`), re-merging any line that isn't a real
+  //      record start (a false split inside a multiline value), rather than splitting on raw \n.
+  let text: string
+  try {
+    text = exec("ps", ["-Eww", "-o", "pid=,command=", "-p", pids.join(",")])
+  } catch {
+    return rows // env unreadable → every slug null → reap nothing this pass (fail closed)
+  }
+  const records: string[] = []
+  for (const chunk of text.split(/\n(?=\d+ )/)) {
+    const pid = Number(chunk.match(/^(\d+) /)?.[1])
+    const argv = byPid.get(pid)?.command
+    if (argv !== undefined && chunk.startsWith(`${pid} ${argv}`)) records.push(chunk)
+    else if (records.length) records[records.length - 1] += `\n${chunk}` // false split → re-merge
+  }
+  for (const rec of records) {
+    const pid = Number(rec.slice(0, rec.indexOf(" ")))
+    const row = byPid.get(pid)
+    if (!row) continue
+    const envSegment = rec.slice(`${pid} ${row.command}`.length)
+    row.slug = envSegment.match(SLUG_RE)?.[1] ?? null
+  }
+  return rows
+}
+
+const defaultKill = (pid: number): void => {
+  try {
+    process.kill(pid, "SIGKILL")
+  } catch {
+    // already gone / not permitted — idempotent
+  }
+}
+
+/** Expand seeds to subtrees and SIGKILL leaves-first. Returns the count actually signalled. */
+export function reapSubtrees(
+  seed: readonly number[],
+  rows: readonly ProcRow[],
+  protectedPids: ReadonlySet<number>,
+  live: ReadonlySet<string>,
+  kill: (pid: number) => void = defaultKill,
+): number {
+  const keep = (row: ProcRow): boolean =>
+    protectedPids.has(row.pid) ||
+    isSessionRoot(row.command) ||
+    isTmuxServer(row.command) ||
+    (row.slug !== null && live.has(row.slug))
+  const order = subtreeKillOrder(seed, rows, keep)
+  for (const pid of order) kill(pid)
+  return order.length
+}
+
+// ---- Orchestration --------------------------------------------------------------------------------
+
+export interface SweepDeps {
+  exec?: Exec
+  kill?: (pid: number) => void
+  selfPid?: number
+  minAgeMs?: number
+  log?: (msg: string) => void
+}
+
+export interface SweepResult {
+  /** total processes SIGKILLed (aux roots + their descendants) */
+  reaped: number
+  /** distinct dead thread slugs whose aux were reaped */
+  deadSlugs: string[]
+  liveSlugs: string[]
+}
+
+/** One periodic sweep: enumerate → decide → reap. Never throws (fails closed). */
+export function sweepOrphansOnce(deps: SweepDeps = {}): SweepResult {
+  const exec = deps.exec ?? defaultExec
+  const selfPid = deps.selfPid ?? process.pid
+  const minAgeMs = deps.minAgeMs ?? ORPHAN_MIN_AGE_MS
+  let rows: ProcRow[]
+  try {
+    rows = enumerateProcs(exec)
+  } catch {
+    return { reaped: 0, deadSlugs: [], liveSlugs: [] }
+  }
+  const protectedPids = selfAndAncestors(rows, selfPid)
+  const { reap, liveSlugs } = decideOrphans(rows, { minAgeMs, protectedPids })
+  if (!reap.length) return { reaped: 0, deadSlugs: [], liveSlugs }
+  const bySlug = new Map(rows.map((r) => [r.pid, r.slug]))
+  const deadSlugs = [...new Set(reap.map((pid) => bySlug.get(pid)).filter((s): s is string => !!s))]
+  const live = new Set(liveSlugs)
+  const reaped = reapSubtrees(reap, rows, protectedPids, live, deps.kill)
+  deps.log?.(
+    `orphan-reaper: reaped ${reaped} process(es) from ${deadSlugs.length} dead thread(s): ${deadSlugs.join(", ")}`,
+  )
+  return { reaped, deadSlugs, liveSlugs }
+}
+
+/** Start the startup + periodic sweep. Returns a stop handle. Timer is unref'd (never holds the loop open). */
+export function startOrphanReaper(deps: SweepDeps & { intervalMs?: number } = {}): () => void {
+  const intervalMs = deps.intervalMs ?? ORPHAN_REAP_INTERVAL_MS
+  try {
+    sweepOrphansOnce(deps)
+  } catch {
+    // startup sweep is best-effort
+  }
+  const timer = setInterval(() => {
+    try {
+      sweepOrphansOnce(deps)
+    } catch {
+      // never let a sweep error escape the timer
+    }
+  }, intervalMs)
+  timer.unref?.()
+  return () => clearInterval(timer)
+}

--- a/ui/scripts/adhoc-stack.mjs
+++ b/ui/scripts/adhoc-stack.mjs
@@ -10,7 +10,7 @@
 // The project defaults to the fray repo itself (a gh-authed repo, an empty board under the temp HOME).
 //
 // Usage:
-//   npx tsx ui/scripts/adhoc-stack.mjs [--port=4930] [--project=/abs/dir] [--wakers] [--keep] [--seed]
+//   npx tsx ui/scripts/adhoc-stack.mjs [--port=4930] [--project=/abs/dir] [--wakers] [--reaper] [--keep] [--seed]
 //
 // It prints ONE json line to stdout: {"url","port","home","socket","project"} once /health is green,
 // then stays up until SIGINT/SIGTERM, deleting the temp HOME on exit (unless --keep). Run it with Bash
@@ -37,6 +37,10 @@ mkdirSync(join(home, ".fray"), { recursive: true })
 process.env.HOME = home
 process.env.FRAY_TMUX_SOCKET = `fray-adhoc-${port}-${process.pid}`
 if (!flag("wakers")) process.env.FRAY_WAKERS_OFF = "1"
+// A disposable stack must never reap the real machine's leaked worker processes (the orphan reaper
+// enumerates ALL processes, not just this stack's). Off by default, exactly like the scheduler; pass
+// --reaper to arm it when verifying the reaper itself.
+if (!flag("reaper")) process.env.FRAY_ORPHAN_REAPER_OFF = "1"
 process.chdir(projectDir)
 
 // Optional: drop a tiny fixture note so the board isn't stone empty when eyeballing the shell. Off by

--- a/ui/scripts/verify-orphan-reaper.mjs
+++ b/ui/scripts/verify-orphan-reaper.mjs
@@ -1,0 +1,116 @@
+// Real-subsystem harness for the orphan reaper (fray:adhoc-cdp §3). Unit tests drive the pure logic
+// with a FAKE ps; this drives the REAL `ps -axo` + `ps -Eww` env read and a REAL SIGKILL against
+// REAL processes, with a NEGATIVE CONTROL (a live-slug root + its aux that MUST survive). Mocks
+// prove nothing about whether macOS ps actually surfaces FRAY_UI_THREAD from the environment.
+//
+//   run: npx tsx scripts/verify-orphan-reaper.mjs   (from ui/)   → PASS/FAIL lines; exit 1 on any fail.
+//
+// Uses REAL `node` processes — the production shape of leaked aux (MCP/dev servers, and Chrome,
+// whose env `ps -E` surfaces identically; verified separately). System binaries like /bin/sleep are
+// deliberately NOT used: macOS restricts `ps -E` env reads for SIP platform binaries, which are
+// never what a worker leaks.
+//
+// Controlled processes (all real, detached):
+//   root   = `node` invoked through a symlink named `claude` → a SESSION ROOT (by basename), defines LIVE
+//   liveAux= a `node` tagged LIVE → aux whose slug HAS a live root → must be KEPT
+//   orphan = a `node` tagged DEAD → aux whose slug has NO root      → must be REAPED
+// Only `orphan` is ever really killed; the harness never sweeps the machine with a live SIGKILL.
+
+import { spawn } from "node:child_process"
+import { mkdtempSync, symlinkSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  enumerateProcs,
+  decideOrphans,
+  selfAndAncestors,
+  reapSubtrees,
+  sweepOrphansOnce,
+  isSessionRoot,
+} from "../packages/server/src/orphan-reaper.ts"
+
+let pass = 0
+let fail = 0
+const ok = (cond, msg) => {
+  if (cond) { pass++; console.log("PASS", msg) } else { fail++; console.log("FAIL", msg) }
+}
+const alive = (pid) => { try { process.kill(pid, 0); return true } catch { return false } }
+const wait = (ms) => new Promise((r) => setTimeout(r, ms))
+
+const uniq = `${process.pid}-${Date.now().toString(36)}`
+const LIVE = `reaper-harness-live-${uniq}`
+const DEAD = `reaper-harness-dead-${uniq}`
+const IDLE = "node -e globalThis.__k=setInterval(()=>{},1e9)" // keep the proc alive; harmless
+
+const dir = mkdtempSync(join(tmpdir(), "reaper-harness-"))
+const fakeClaude = join(dir, "claude") // basename 'claude' → session root; really a symlink to node → env-readable
+symlinkSync(process.execPath, fakeClaude)
+
+const spawned = []
+const spawnTagged = (cmd, args, slug) => {
+  const child = spawn(cmd, args, { detached: true, stdio: "ignore", env: { ...process.env, FRAY_UI_THREAD: slug } })
+  child.unref()
+  spawned.push(child.pid)
+  return child.pid
+}
+const cleanup = () => {
+  for (const pid of spawned) { try { process.kill(pid, "SIGKILL") } catch {} }
+  try { rmSync(dir, { recursive: true, force: true }) } catch {}
+}
+
+try {
+  const idleArgs = ["-e", "setInterval(()=>{},1e9)"]
+  // node rejects an unknown --session-id flag; the `claude` symlink basename alone marks it a root.
+  const rootPid = spawnTagged(fakeClaude, idleArgs, LIVE)
+  const liveAuxPid = spawnTagged(process.execPath, idleArgs, LIVE)
+  const orphanPid = spawnTagged(process.execPath, idleArgs, DEAD)
+  // CRITICAL regression: a root whose ARGV contains a literal FRAY_UI_THREAD=<other> (pasted task
+  // text) but whose ENV owns SPOOF. Ownership must read from ENV, else SPOOF looks dead and spoofAux
+  // gets reaped mid-run. (The positional `note:` token is not a --flag, so node keeps running.)
+  const SPOOF = `reaper-harness-spoof-${uniq}`
+  const spoofRootPid = spawnTagged(fakeClaude, [...idleArgs, `note:FRAY_UI_THREAD=argv-decoy-${uniq}`], SPOOF)
+  const spoofAuxPid = spawnTagged(process.execPath, idleArgs, SPOOF)
+  await wait(700) // let them register in the process table
+
+  // 1) REAL enumeration: ps -axo joined with ps -Eww env read
+  const rows = enumerateProcs()
+  const find = (pid) => rows.find((r) => r.pid === pid)
+  ok(find(rootPid)?.slug === LIVE, "real ps -Eww surfaces FRAY_UI_THREAD env for the root")
+  ok(find(liveAuxPid)?.slug === LIVE, "real ps -Eww surfaces the live-aux slug")
+  ok(find(orphanPid)?.slug === DEAD, "real ps -Eww surfaces the orphan slug")
+  ok(!!find(rootPid) && isSessionRoot(find(rootPid).command), "a binary named `claude` classified a session root")
+  ok(!!find(orphanPid) && !isSessionRoot(find(orphanPid).command), "plain node classified aux, not a session root")
+  // CRITICAL: the spoof root's slug must read from ENV (SPOOF), NOT the argv decoy literal
+  ok(find(spoofRootPid)?.slug === SPOOF, "root slug read from ENV, argv `FRAY_UI_THREAD=` literal ignored")
+
+  const protectedPids = selfAndAncestors(rows, process.pid)
+
+  // 2) decideOrphans on the REAL table: orphan in, root/liveAux/self out
+  const { reap, liveSlugs } = decideOrphans(rows, { minAgeMs: 0, protectedPids })
+  const reapSet = new Set(reap)
+  ok(reapSet.has(orphanPid), "orphan (dead slug) selected for reaping")
+  ok(!reapSet.has(rootPid), "session root NEVER selected")
+  ok(!reapSet.has(liveAuxPid), "live-slug aux NEVER selected (negative control)")
+  ok(!reapSet.has(process.pid), "the harness's own pid NEVER selected")
+  ok(liveSlugs.includes(LIVE), "LIVE slug reported live (its root is alive)")
+
+  // 3) full sweep path, DRY RUN (record kills, don't signal) — proves the real orchestration
+  const recorded = []
+  sweepOrphansOnce({ minAgeMs: 0, selfPid: process.pid, kill: (pid) => recorded.push(pid) })
+  const rec = new Set(recorded)
+  ok(rec.has(orphanPid), "full sweep would reap the orphan")
+  ok(!rec.has(rootPid) && !rec.has(liveAuxPid), "full sweep spares root + live-slug aux")
+  ok(!rec.has(spoofRootPid) && !rec.has(spoofAuxPid), "full sweep spares the spoof root AND its aux (no argv mis-attribution)")
+
+  // 4) REAL kill of ONLY the orphan; negative control must still be alive after
+  reapSubtrees([orphanPid], rows, protectedPids, new Set(liveSlugs), (pid) => { try { process.kill(pid, "SIGKILL") } catch {} })
+  await wait(300)
+  ok(!alive(orphanPid), "orphan is REALLY dead after reap")
+  ok(alive(rootPid), "session root still alive (never touched)")
+  ok(alive(liveAuxPid), "live-slug aux still alive (never touched)")
+} finally {
+  cleanup()
+}
+
+console.log(`\n${pass} passed, ${fail} failed`)
+process.exit(fail ? 1 : 0)


### PR DESCRIPTION
## Problem

fray spawns a detached `claude`/`codex` worker per thread; each worker spawns verification browsers (`agent-browser`/`chrome-devtools`/puppeteer) and MCP/dev servers for its task. `tmux kill-session` signals only the pane's process group, so anything that **daemonized out of it** — `agent-browser` double-forks its Chrome to `launchd`; a `node --watch` reparents on crash — survives the stop and **leaks permanently**, since nothing else collects it. Over days this accretes **GBs of orphaned Chrome/node** whose owning thread is long gone. (This surfaced from a real cleanup where ~12 GB of automation Chrome + 5.5 GB of MCP servers had accumulated across dead threads.)

## Fix

A **startup + periodic (60s) orphan reaper** wired into the server context (`orphan-reaper.ts`).

**Ownership** is read from the env marker every worker carries — `FRAY_UI_THREAD=<slug>`, inherited by all children. A slug is *live* iff a live `claude`/`codex` **session process** still carries it (a worker's only OS-level agent process is its session root — Agent sub-agents are in-process — so this is exact and **socket-agnostic**, protecting live adhoc-stack workers automatically).

**Safety** — the reaper kills ONLY auxiliary processes whose slug is live *nowhere*, and never:
- a session root (`claude`/`codex`, or anything with `--session-id`)
- a `tmux` server
- the reaper's own process or any ancestor (so it can't kill the server it runs in — which is untagged anyway, being user-spawned)
- any process whose slug is currently live

Every enumeration failure **fails closed** (reap nothing); a 120s age guard skips just-spawned processes.

**Slug read from ENV, not argv**: two `ps` passes (argv, then `-Eww` env) joined per pid, with the pass-1 argv stripped so a literal `FRAY_UI_THREAD=x` in a process's own argv (pasted task text, a `tmux -e` flag) can't spoof ownership. Env values containing newlines (PEM keys, service-account JSON) are handled by delimiting records on their `<pid> <argv>` marker rather than raw newlines. The full env line never escapes enumeration beyond the slug regex, so **process secrets are never stored or logged**.

`FRAY_ORPHAN_REAPER_OFF` disables it for disposable adhoc/test stacks (mirrors `FRAY_WAKERS_OFF`) so a throwaway instance never reaps the real machine; `adhoc-stack.mjs` sets it by default and adds a symmetric `--reaper` opt-in.

## Verification

- **19 unit tests** over the pure decision + enumeration logic (injectable `ps`/kill adapters), including argv-spoof and multiline-env regressions.
- **Real-subsystem harness** (`scripts/verify-orphan-reaper.mjs`): real `ps -Eww` env reads + real `SIGKILL` against real `node` processes, with negative controls (a live-slug root + its aux, and an argv-spoof root) that must survive.
- **Real-machine dry run**: enumerated 1290 live processes, read all 58 session roots + own slug correctly, **0 session roots** in the reap set.
- **Driven end-to-end in the running server** via the adhoc stack: `--reaper` startup sweep reaped an aged known orphan plus real leaked processes from dead threads while sparing live-slug controls; clean boot + shutdown; with the reaper off the machine was untouched.
- Independent fresh-context adversarial review; its one CONFIRMED critical finding (argv-vs-env slug mis-attribution) is fixed here and covered by regressions.

## Follow-up (not in this PR — needs a product decision)

The largest memory pile is **idle worker processes themselves** (a thread resting for days keeps a live ~100–400 MB `claude` + its MCP server). Reaping/hibernating those is a policy/TTL call (what's the TTL; does auto-stopping a parked thread surprise the user), so it's deliberately left out. This PR handles the unambiguous aux leaks.

https://claude.ai/code/session_016ndfnyfStBWRYBK8VFTwLq