### PR TITLE
Flatten snooze callouts and queue agent rows

### DIFF
--- a/ui/packages/web/src/components/ChatView.tsx
+++ b/ui/packages/web/src/components/ChatView.tsx
@@ -3,7 +3,7 @@ import { useSnapshot } from "valtio"
 import * as RadixTabs from "@radix-ui/react-tabs"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useVirtualizer } from "@tanstack/react-virtual"
-import { AlertTriangle, ArrowDown, ArrowLeft, ArrowUpRight, Check, ChevronRight, FileText, HelpCircle, KeyRound, ListChecks, Loader2, ShieldCheck, Sparkles, X } from "lucide-react"
+import { AlertTriangle, ArrowDown, ArrowLeft, ArrowUpRight, Bell, Check, ChevronRight, FileText, HelpCircle, KeyRound, ListChecks, Loader2, ShieldCheck, Sparkles, X } from "lucide-react"
 import type { AwaitingHint, NativeInputRequired as NativeInputRequiredData, PendingAsk, ThreadView as ThreadViewData, TranscriptEdit, TranscriptMessage, TranscriptToolCall } from "@fray-ui/shared"
 import { isValidAwaitingTimer } from "@fray-ui/shared"
 import { store, threadBySlug, pushDrawer, pushSubAgentDrawer, showToast } from "../store.ts"
@@ -21,7 +21,7 @@ import { useLocalFileCodeLinks } from "../lib/localFileCode.ts"
 import { shouldSubmitComposerEnter } from "../lib/composerKeyboard.ts"
 import { messagePresentationText } from "../lib/messagePresentation.ts"
 import { snoozePresetInstant, formatSnoozeWake } from "../lib/snooze.ts"
-import { awaitingHintSentence, awaitingPresentationLine } from "../lib/awaitingPresentation.ts"
+import { awaitingCalloutPresentation } from "../lib/awaitingPresentation.ts"
 import { prefs } from "../lib/prefs.ts"
 import { canAdoptThread } from "../lib/adoption.ts"
 import { THREAD_TITLE_MAX_LENGTH, aiRenameAvailability, manualThreadTitleSeed, threadTitleToCommit } from "../lib/threadTitle.ts"
@@ -2338,12 +2338,15 @@ export function QuestionBlockCard({
 // A SIGNAL fence rendered as a card in place of the raw ```done / ```awaiting block (the fence
 // language IS the state; the body is the message). `done` → a compact presentation-only success card;
 // its thread's Archive lives in the stable lifecycle footer. `awaiting` → one compact handoff row:
-// body prose plus one plain-English action summary (with legacy pr/ci/session support).
+// one plain-English action lead plus the worker's supporting prose (with legacy pr/ci/session support).
 export function FenceCard({ fenceKind, body, hints, wrap }: { fenceKind: FenceKind; body: string; hints: AwaitingHint[]; wrap?: boolean }) {
   const html = useMemo(() => (body ? mdToHtml(body) : ""), [body])
-  const awaitingHint = awaitingHintSentence(hints)
-  const awaitingLine = awaitingPresentationLine(body, awaitingHint)
-  const awaitingHtml = useMemo(() => mdInlineToHtml(awaitingLine), [awaitingLine])
+  const awaitingCallout = awaitingCalloutPresentation(body, hints)
+  const awaitingLeadHtml = useMemo(() => mdInlineToHtml(awaitingCallout.lead), [awaitingCallout.lead])
+  const awaitingDescriptionHtml = useMemo(
+    () => (awaitingCallout.description ? mdInlineToHtml(awaitingCallout.description) : ""),
+    [awaitingCallout.description],
+  )
   // The owning thread's slug — set by the thread view AND the queue card — so the confirm button
   // resolves its thread and renders on both surfaces (null in a sub-agent's own transcript → no button).
   const slug = useContext(ThreadSlugContext)
@@ -2393,11 +2396,19 @@ export function FenceCard({ fenceKind, body, hints, wrap }: { fenceKind: FenceKi
     )
   }
   return (
-    <div className="flex min-w-0 items-stretch rounded-lg border border-border-strong bg-panel-2">
-      <div
-        className={`md-inline min-w-0 flex-1 content-center px-3 py-2 text-[12px] leading-5 text-fg/85${wrap ? ` ${QUEUE_WRAP}` : ""}`}
-        dangerouslySetInnerHTML={{ __html: awaitingHtml }}
-      />
+    <div className="min-w-0 overflow-hidden rounded-lg border border-border-strong bg-panel-2">
+      <div className={`flex min-w-0 items-start gap-2.5 px-3 py-2.5 text-[12px] leading-5 text-fg/80${wrap ? ` ${QUEUE_WRAP}` : ""}`}>
+        <Bell aria-hidden="true" size={13} className="mt-[3px] shrink-0 text-muted/65" />
+        <div className="min-w-0">
+          <strong className="md-inline font-semibold text-fg/90" dangerouslySetInnerHTML={{ __html: awaitingLeadHtml }} />
+          {awaitingDescriptionHtml && (
+            <>
+              <span aria-hidden="true"> — </span>
+              <span className="md-inline" dangerouslySetInnerHTML={{ __html: awaitingDescriptionHtml }} />
+            </>
+          )}
+        </div>
+      </div>
       {canAct && fenceThread && <AwaitingParkButton thread={fenceThread} hints={hints} />}
     </div>
   )
@@ -2447,7 +2458,7 @@ function AwaitingParkButton({ thread, hints }: { thread: ThreadViewData; hints: 
       .finally(() => setBusy(false))
   }
   return (
-    <div className="flex shrink-0 items-center justify-end border-l border-border px-2 py-1.5">
+    <div className="flex items-center justify-end border-t border-border bg-panel px-3 py-1.5">
       <button
         type="button"
         onClick={apply}
@@ -2455,7 +2466,7 @@ function AwaitingParkButton({ thread, hints }: { thread: ThreadViewData; hints: 
         aria-label={action.label}
         title={action.label}
         onMouseDown={(e) => e.preventDefault()}
-        className="flex items-center gap-1.5 whitespace-nowrap rounded-md border border-border bg-panel px-2 py-1 text-[11px] font-medium text-fg/85 outline-none transition-colors hover:border-border-strong hover:bg-panel-2 hover:text-fg focus-visible:ring-1 focus-visible:ring-fg/60 disabled:opacity-45"
+        className="flex items-center gap-1.5 whitespace-nowrap rounded-md bg-fg px-2.5 py-1 text-[11px] font-medium text-bg outline-none focus-visible:ring-1 focus-visible:ring-fg/60 disabled:cursor-wait disabled:opacity-100"
       >
         {busy && <Loader2 size={11} className="animate-spin" />}
         {action.label}

--- a/ui/packages/web/src/components/ChatView.tsx
+++ b/ui/packages/web/src/components/ChatView.tsx
@@ -1200,6 +1200,12 @@ function shortenTarget(detail: string): string {
 // activity doesn't dwarf the prose it belongs to.
 const COLLAPSE_AT = 4
 
+function toolCallsForSurface(tools: CollapsedTool[], dense?: boolean): CollapsedTool[] {
+  // Queue cards already render live children once, as borderless QueueSubAgentLines below the reply.
+  // Keep Agent prompt history in the full transcript instead of nesting another bordered card here.
+  return dense ? tools.filter((tool) => !tool.prompt) : tools
+}
+
 function ToolCalls({ tools, dense }: { tools: CollapsedTool[]; dense?: boolean }) {
   const [expanded, setExpanded] = useState(false)
   const cardsId = useId()
@@ -1686,7 +1692,7 @@ export function AgentBlock({
   }
 
   return (
-    <div className="fray-bash">
+    <div className="fray-bash" data-agent-tool-card>
       <ToolDisclosureHeader
         className="fray-bash-header"
         controls={bodyId}
@@ -2025,7 +2031,7 @@ export const Message = memo(function Message({ m, answering, dense, paired, stic
         // textOnly (the queue card's first/last agent message): the batched tool band is dropped so only
         // the agent's prose remains — its calls live inside the collapsed intermediate bar instead.
         if (textOnly) return
-        const collapsed = collapseTools(part.tools)
+        const collapsed = toolCallsForSurface(collapseTools(part.tools), dense)
         if (collapsed.length) blocks.push(<ToolCalls key={`t${pi}`} tools={collapsed} dense={dense} />)
       } else {
         renderText(part.text, `x${pi}`)
@@ -2035,7 +2041,7 @@ export const Message = memo(function Message({ m, answering, dense, paired, stic
     // LEGACY fallback (a pre-restart server ships no `parts`): the old flat layout — tool band first,
     // then all prose. Degrades to today's (order-lossy) rendering until the server bounce.
     if (!textOnly) {
-      const collapsed = collapseTools(m.tools)
+      const collapsed = toolCallsForSurface(collapseTools(m.tools), dense)
       if (collapsed.length > 0) blocks.push(<ToolCalls key="tools" tools={collapsed} dense={dense} />)
     }
     renderText(m.text, "leg")
@@ -2337,8 +2343,8 @@ export function QuestionBlockCard({
 
 // A SIGNAL fence rendered as a card in place of the raw ```done / ```awaiting block (the fence
 // language IS the state; the body is the message). `done` → a compact presentation-only success card;
-// its thread's Archive lives in the stable lifecycle footer. `awaiting` → one compact handoff row:
-// one plain-English action lead plus the worker's supporting prose (with legacy pr/ci/session support).
+// its thread's Archive lives in the stable lifecycle footer. `awaiting` → one compact callout:
+// a short semantic subtitle plus plain-English action detail and the worker's supporting prose.
 export function FenceCard({ fenceKind, body, hints, wrap }: { fenceKind: FenceKind; body: string; hints: AwaitingHint[]; wrap?: boolean }) {
   const html = useMemo(() => (body ? mdToHtml(body) : ""), [body])
   const awaitingCallout = awaitingCalloutPresentation(body, hints)
@@ -2396,8 +2402,8 @@ export function FenceCard({ fenceKind, body, hints, wrap }: { fenceKind: FenceKi
     )
   }
   return (
-    <div className="min-w-0 overflow-hidden rounded-lg border border-border-strong bg-panel-2">
-      <div className={`flex min-w-0 items-start gap-2.5 px-3 py-2.5 text-[12px] leading-5 text-fg/80${wrap ? ` ${QUEUE_WRAP}` : ""}`}>
+    <div data-awaiting-callout className="min-w-0 overflow-hidden rounded-lg border border-border-strong bg-panel-2">
+      <div data-awaiting-callout-body className={`flex min-w-0 items-start gap-2.5 px-3 py-2 text-[12px] leading-5 text-fg/80${wrap ? ` ${QUEUE_WRAP}` : ""}`}>
         <Bell aria-hidden="true" size={13} className="mt-[3px] shrink-0 text-muted/65" />
         <div className="min-w-0">
           <strong className="md-inline font-semibold text-fg/90" dangerouslySetInnerHTML={{ __html: awaitingLeadHtml }} />
@@ -2458,7 +2464,7 @@ function AwaitingParkButton({ thread, hints }: { thread: ThreadViewData; hints: 
       .finally(() => setBusy(false))
   }
   return (
-    <div className="flex items-center justify-end border-t border-border bg-panel px-3 py-1.5">
+    <div data-awaiting-callout-footer className="flex items-center justify-end border-t border-border bg-panel px-2.5 py-1">
       <button
         type="button"
         onClick={apply}
@@ -2466,9 +2472,9 @@ function AwaitingParkButton({ thread, hints }: { thread: ThreadViewData; hints: 
         aria-label={action.label}
         title={action.label}
         onMouseDown={(e) => e.preventDefault()}
-        className="flex items-center gap-1.5 whitespace-nowrap rounded-md bg-fg px-2.5 py-1 text-[11px] font-medium text-bg outline-none focus-visible:ring-1 focus-visible:ring-fg/60 disabled:cursor-wait disabled:opacity-100"
+        className="relative flex items-center gap-1 whitespace-nowrap rounded-md bg-fg px-2 py-0.5 text-[10px] font-medium leading-4 text-bg outline-none after:absolute after:-inset-0.5 after:content-[''] focus-visible:ring-1 focus-visible:ring-fg/60 disabled:cursor-wait disabled:opacity-100"
       >
-        {busy && <Loader2 size={11} className="animate-spin" />}
+        {busy && <Loader2 size={10} className="animate-spin" />}
         {action.label}
       </button>
     </div>

--- a/ui/packages/web/src/done-card-button-fixture.tsx
+++ b/ui/packages/web/src/done-card-button-fixture.tsx
@@ -14,6 +14,7 @@ import "./styles.css"
 //     a user snooze via setThreadSnooze.
 // RPC is mocked like completion-lifecycle-fixture so nothing real is hit.
 const mode = new URLSearchParams(window.location.search).get("mode") === "executing" ? "executing" : "resting"
+const calloutsOnly = new URLSearchParams(window.location.search).get("callouts") === "1"
 const nativeFetch = window.fetch.bind(window)
 const rpcResult = (result: unknown) => new Response(JSON.stringify({ result }), {
   headers: { "content-type": "application/json", "x-fray-boot": "done-card-button-fixture" },
@@ -106,6 +107,18 @@ function Fixture() {
     window.addEventListener("fixture-rpc", onRpc)
     return () => window.removeEventListener("fixture-rpc", onRpc)
   }, [])
+  if (calloutsOnly) {
+    return (
+      <main data-callout-gallery className="mx-auto flex min-h-screen w-full max-w-xl flex-col gap-3 px-4 py-8">
+        {cards.filter((card) => card.fence === "awaiting").map((card) => (
+          <ThreadSlugContext.Provider key={card.slug} value={card.slug}>
+            <FenceCard fenceKind={card.fence} body={card.body} hints={card.hints} />
+          </ThreadSlugContext.Provider>
+        ))}
+        <p data-fixture-rpc-calls className="sr-only">RPC calls: {calls.join(" | ") || "none"}</p>
+      </main>
+    )
+  }
   return (
     <main className="mx-auto flex min-h-screen w-full max-w-xl flex-col gap-5 px-4 py-8">
       <p className="petite-caps text-[10px] text-accent">FenceCard buttons ({mode})</p>

--- a/ui/packages/web/src/done-card-button-fixture.tsx
+++ b/ui/packages/web/src/done-card-button-fixture.tsx
@@ -2,6 +2,7 @@ import { createRoot } from "react-dom/client"
 import { useEffect, useState } from "react"
 import type { AwaitingHint, BoardSnapshot, ThreadView } from "@fray-ui/shared"
 import { FenceCard, ThreadSlugContext, Message } from "./components/ChatView.tsx"
+import { QueueSubAgentLines } from "./components/QueueSubAgentLines.tsx"
 import { setBoard } from "./store.ts"
 import "./styles.css"
 
@@ -15,6 +16,9 @@ import "./styles.css"
 // RPC is mocked like completion-lifecycle-fixture so nothing real is hit.
 const mode = new URLSearchParams(window.location.search).get("mode") === "executing" ? "executing" : "resting"
 const calloutsOnly = new URLSearchParams(window.location.search).get("callouts") === "1"
+const agentOnly = new URLSearchParams(window.location.search).get("agent") === "1"
+const requestedDelay = Number(new URLSearchParams(window.location.search).get("delay") ?? "0")
+const responseDelayMs = Number.isFinite(requestedDelay) ? Math.min(Math.max(requestedDelay, 0), 5_000) : 0
 const nativeFetch = window.fetch.bind(window)
 const rpcResult = (result: unknown) => new Response(JSON.stringify({ result }), {
   headers: { "content-type": "application/json", "x-fray-boot": "done-card-button-fixture" },
@@ -29,6 +33,7 @@ window.fetch = async (input, init) => {
   }
   if (url.pathname === "/rpc/setThreadSnooze") {
     const body = JSON.parse(String(init?.body ?? "{}")) as { slug?: string; until?: string }
+    if (responseDelayMs) await new Promise((resolve) => setTimeout(resolve, responseDelayMs))
     window.dispatchEvent(new CustomEvent("fixture-rpc", { detail: { rpc: "setThreadSnooze", ...body } }))
     return rpcResult(null)
   }
@@ -77,8 +82,8 @@ const queueCards: { slug: string; label: string; text: string }[] = [
   { slug: "queue-timer", label: "timer snooze", text: "```awaiting\nPark until the checkpoint.\ntimer: " + timerIso + "\n```" },
 ]
 
-// A queue thread with a LIVE sub-agent dispatch — proves that, now the queue card provides
-// ThreadSlugContext, an AgentBlock there resolves its child and goes live (running header + drill-in).
+// A queue thread with a LIVE sub-agent dispatch. Dense messages intentionally omit the nested Agent
+// tool card; QueueSubAgentLines is the queue's one flat, drillable child surface.
 const agentSlug = "queue-agent"
 const agentId = "sub-live-1"
 const agentThread = baseThread(agentSlug, "agent · live sub-agent", [
@@ -95,6 +100,13 @@ const board: BoardSnapshot = {
   warnings: [],
 }
 setBoard(board)
+
+const agentMessage = {
+  role: "assistant" as const,
+  text: "",
+  tools: [],
+  parts: [{ kind: "tools" as const, tools: [{ name: "Agent", detail: "Investigate the failing test", prompt: "Go investigate the failing test and report back.", subagentType: "fray:opus-high", agentId, status: "pending" as const }] }],
+}
 
 function Fixture() {
   const [calls, setCalls] = useState<string[]>([])
@@ -119,43 +131,46 @@ function Fixture() {
       </main>
     )
   }
+  if (agentOnly) {
+    return (
+      <main data-agent-gallery className="mx-auto min-h-screen w-full max-w-xl px-4 py-8">
+        <article data-agent-queue-card className="overflow-hidden rounded-lg border border-border bg-panel">
+          <header className="border-b border-border/60 px-4 py-3">
+            <strong className="text-[13px] font-semibold">Fix queue regression</strong>
+          </header>
+          <div className="px-4 py-3">
+            <ThreadSlugContext.Provider value={agentSlug}>
+              <Message m={agentMessage} dense />
+            </ThreadSlugContext.Provider>
+            <QueueSubAgentLines slug={agentSlug} subAgents={agentThread.subAgents} />
+          </div>
+        </article>
+      </main>
+    )
+  }
   return (
-    <main className="mx-auto flex min-h-screen w-full max-w-xl flex-col gap-5 px-4 py-8">
-      <p className="petite-caps text-[10px] text-accent">FenceCard buttons ({mode})</p>
+    <main className="mx-auto flex min-h-screen w-full max-w-xl flex-col gap-3 px-4 py-8">
       {cards.map((c) => (
-        <div key={c.slug} className="flex flex-col gap-1.5">
-          <p className="text-[11px] text-muted">{c.label}</p>
+        <div key={c.slug} data-fixture-label={c.label}>
           <ThreadSlugContext.Provider value={c.slug}>
             <FenceCard fenceKind={c.fence} body={c.body} hints={c.hints} />
           </ThreadSlugContext.Provider>
         </div>
       ))}
-      <p className="petite-caps mt-4 text-[10px] text-accent">Queue path — Message dense inside ThreadSlugContext</p>
       {queueCards.map((c) => (
-        <div key={c.slug} data-queue-fixture={c.slug} className="flex flex-col gap-1.5 rounded-lg border border-border bg-panel p-3">
-          <p className="text-[11px] text-muted">{c.label}</p>
+        <div key={c.slug} data-queue-fixture={c.slug} data-fixture-label={c.label}>
           <ThreadSlugContext.Provider value={c.slug}>
             <Message m={{ role: "assistant", text: c.text, tools: [], parts: [{ kind: "text", text: c.text }] }} dense />
           </ThreadSlugContext.Provider>
         </div>
       ))}
-      {/* B (maintainer 2026-07-15): queue sub-agent blocks go live via ThreadSlugContext. This proves an
-          AgentBlock in a queue card resolves its running child + offers drill-in. */}
-      <div data-queue-fixture={agentSlug} className="flex flex-col gap-1.5 rounded-lg border border-border bg-panel p-3">
-        <p className="text-[11px] text-muted">agent · live sub-agent (drill-in)</p>
+      <div data-queue-fixture={agentSlug}>
         <ThreadSlugContext.Provider value={agentSlug}>
-          <Message
-            m={{
-              role: "assistant",
-              text: "",
-              tools: [],
-              parts: [{ kind: "tools", tools: [{ name: "Agent", detail: "Investigate the failing test", prompt: "Go investigate the failing test and report back.", subagentType: "fray:opus-high", agentId, status: "pending" }] }],
-            }}
-            dense
-          />
+          <Message m={agentMessage} dense />
         </ThreadSlugContext.Provider>
+        <QueueSubAgentLines slug={agentSlug} subAgents={agentThread.subAgents} />
       </div>
-      <p data-fixture-rpc-calls className="text-[11px] text-muted">RPC calls: {calls.join(" | ") || "none"}</p>
+      <p data-fixture-rpc-calls className="sr-only">RPC calls: {calls.join(" | ") || "none"}</p>
     </main>
   )
 }

--- a/ui/packages/web/src/lib/awaitingPresentation.test.ts
+++ b/ui/packages/web/src/lib/awaitingPresentation.test.ts
@@ -7,7 +7,7 @@ const now = Date.parse("2026-07-21T18:00:00.000Z")
 test("awaiting hints become one compact plain-English action", () => {
   assert.match(
     awaitingHintSentence([{ kind: "timer", value: "2026-07-21T21:00:00.000Z" }], now) ?? "",
-    /^Snooze until /,
+    /^Until /,
   )
   assert.equal(
     awaitingHintSentence([{ kind: "github-review", value: "owner/repo#42" }], now),
@@ -47,14 +47,36 @@ test("callout presentation separates the bold action lead from supporting prose"
     [{ kind: "timer", value: "2026-07-21T21:00:00.000Z" }],
     now,
   )
-  assert.match(timer.lead, /^Snooze until /)
-  assert.equal(timer.description, "Park until the checkpoint.")
+  assert.equal(timer.lead, "Recommended snooze")
+  assert.match(timer.description ?? "", /^Until .*\. Park until the checkpoint\.$/)
+  assert.deepEqual(
+    awaitingCalloutPresentation(
+      "The implementation is ready for review.",
+      [{ kind: "github-review", value: "owner/repo#42" }],
+      now,
+    ),
+    {
+      lead: "Review watcher",
+      description: "Watch owner/repo#42 for new human review activity. The implementation is ready for review.",
+    },
+  )
+  assert.deepEqual(
+    awaitingCalloutPresentation(
+      "The API shape needs approval.",
+      [{ kind: "human", value: "Alice to approve the API shape" }],
+      now,
+    ),
+    {
+      lead: "Human approval",
+      description: "Wait for Alice to approve the API shape. The API shape needs approval.",
+    },
+  )
   assert.deepEqual(
     awaitingCalloutPresentation("The worker left a plain handoff.", [], now),
-    { lead: "The worker left a plain handoff.", description: null },
+    { lead: "Wait note", description: "The worker left a plain handoff." },
   )
   assert.deepEqual(
     awaitingCalloutPresentation("", [], now),
-    { lead: "Waiting for an external update", description: null },
+    { lead: "Wait note", description: "Waiting for an external update." },
   )
 })

--- a/ui/packages/web/src/lib/awaitingPresentation.test.ts
+++ b/ui/packages/web/src/lib/awaitingPresentation.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import test from "node:test"
-import { awaitingHintSentence, awaitingPresentationLine } from "./awaitingPresentation.ts"
+import { awaitingCalloutPresentation, awaitingHintSentence } from "./awaitingPresentation.ts"
 
 const now = Date.parse("2026-07-21T18:00:00.000Z")
 
@@ -41,14 +41,20 @@ test("legacy hints degrade to readable text and an empty hint set stays empty", 
   assert.equal(awaitingHintSentence([], now), null)
 })
 
-test("body and action join as clean prose without period-dash punctuation", () => {
-  assert.equal(
-    awaitingPresentationLine("Park until the checkpoint.", "Snooze until today at 2:00 PM"),
-    "Park until the checkpoint. Snooze until today at 2:00 PM",
+test("callout presentation separates the bold action lead from supporting prose", () => {
+  const timer = awaitingCalloutPresentation(
+    "Park until the checkpoint.",
+    [{ kind: "timer", value: "2026-07-21T21:00:00.000Z" }],
+    now,
   )
-  assert.equal(
-    awaitingPresentationLine("Park until the checkpoint", "Snooze until today at 2:00 PM"),
-    "Park until the checkpoint — Snooze until today at 2:00 PM",
+  assert.match(timer.lead, /^Snooze until /)
+  assert.equal(timer.description, "Park until the checkpoint.")
+  assert.deepEqual(
+    awaitingCalloutPresentation("The worker left a plain handoff.", [], now),
+    { lead: "The worker left a plain handoff.", description: null },
   )
-  assert.equal(awaitingPresentationLine("", null), "Waiting for an external update.")
+  assert.deepEqual(
+    awaitingCalloutPresentation("", [], now),
+    { lead: "Waiting for an external update", description: null },
+  )
 })

--- a/ui/packages/web/src/lib/awaitingPresentation.ts
+++ b/ui/packages/web/src/lib/awaitingPresentation.ts
@@ -27,10 +27,14 @@ export function awaitingHintSentence(hints: readonly AwaitingHint[], nowMs = Dat
   return `Wait for session ${legacy.value}`
 }
 
-export function awaitingPresentationLine(body: string, hint: string | null): string {
+export function awaitingCalloutPresentation(
+  body: string,
+  hints: readonly AwaitingHint[],
+  nowMs = Date.now(),
+): { lead: string; description: string | null } {
   const prose = body.trim()
-  if (!prose) return hint ?? "Waiting for an external update."
-  if (!hint) return prose
-  const separator = /[.!?…][*_~`"')\]]*$/.test(prose) ? " " : " — "
-  return `${prose}${separator}${hint}`
+  const hint = awaitingHintSentence(hints, nowMs)
+  if (hint) return { lead: hint, description: prose || null }
+  if (prose) return { lead: prose, description: null }
+  return { lead: "Waiting for an external update", description: null }
 }

--- a/ui/packages/web/src/lib/awaitingPresentation.ts
+++ b/ui/packages/web/src/lib/awaitingPresentation.ts
@@ -5,26 +5,48 @@ function lowerCalendarLead(value: string): string {
   return value.replace(/^(Today|Tomorrow)/, (day) => day.toLowerCase())
 }
 
-export function awaitingHintSentence(hints: readonly AwaitingHint[], nowMs = Date.now()): string | null {
+function awaitingHintPresentation(
+  hints: readonly AwaitingHint[],
+  nowMs = Date.now(),
+): { lead: string; sentence: string } | null {
   const timer = hints.find((hint) => hint.kind === "timer" && isValidAwaitingTimer(hint.value))
   if (timer && Date.parse(timer.value) > nowMs) {
-    return `Snooze until ${lowerCalendarLead(formatSnoozeWake(timer.value, nowMs))}`
+    return {
+      lead: "Recommended snooze",
+      sentence: `Until ${lowerCalendarLead(formatSnoozeWake(timer.value, nowMs))}`,
+    }
   }
 
   const review = hints.find((hint) => hint.kind === "github-review")
-  if (review) return `Watch ${review.value} for new human review activity`
+  if (review) {
+    return {
+      lead: "Review watcher",
+      sentence: `Watch ${review.value} for new human review activity`,
+    }
+  }
 
   const human = hints.find((hint) => hint.kind === "human")
-  if (human) return `Wait for ${human.value}`
+  if (human) return { lead: "Human approval", sentence: `Wait for ${human.value}` }
 
-  if (timer) return `Scheduled for ${lowerCalendarLead(formatSnoozeWake(timer.value, nowMs))}`
-  if (hints.some((hint) => hint.kind === "timer")) return "Snooze schedule unavailable"
+  if (timer) {
+    return {
+      lead: "Scheduled checkpoint",
+      sentence: `Scheduled for ${lowerCalendarLead(formatSnoozeWake(timer.value, nowMs))}`,
+    }
+  }
+  if (hints.some((hint) => hint.kind === "timer")) {
+    return { lead: "Snooze schedule", sentence: "Snooze schedule unavailable" }
+  }
 
   const legacy = hints.find((hint) => hint.kind === "pr" || hint.kind === "ci" || hint.kind === "session")
   if (!legacy) return null
-  if (legacy.kind === "pr") return `Wait for PR ${legacy.value}`
-  if (legacy.kind === "ci") return `Wait for CI ${legacy.value}`
-  return `Wait for session ${legacy.value}`
+  if (legacy.kind === "pr") return { lead: "PR review", sentence: `Wait for PR ${legacy.value}` }
+  if (legacy.kind === "ci") return { lead: "CI check", sentence: `Wait for CI ${legacy.value}` }
+  return { lead: "Related session", sentence: `Wait for session ${legacy.value}` }
+}
+
+export function awaitingHintSentence(hints: readonly AwaitingHint[], nowMs = Date.now()): string | null {
+  return awaitingHintPresentation(hints, nowMs)?.sentence ?? null
 }
 
 export function awaitingCalloutPresentation(
@@ -33,8 +55,13 @@ export function awaitingCalloutPresentation(
   nowMs = Date.now(),
 ): { lead: string; description: string | null } {
   const prose = body.trim()
-  const hint = awaitingHintSentence(hints, nowMs)
-  if (hint) return { lead: hint, description: prose || null }
-  if (prose) return { lead: prose, description: null }
-  return { lead: "Waiting for an external update", description: null }
+  const hint = awaitingHintPresentation(hints, nowMs)
+  if (hint) {
+    const sentence = prose && !/[.!?…]$/.test(hint.sentence) ? `${hint.sentence}.` : hint.sentence
+    return { lead: hint.lead, description: prose ? `${sentence} ${prose}` : sentence }
+  }
+  return {
+    lead: "Wait note",
+    description: prose || "Waiting for an external update.",
+  }
 }


### PR DESCRIPTION
## Summary

- render awaiting fences as compact semantic callouts with an icon, bold subtitle, plain-English detail, and a small right-aligned white confirmation button in a dedicated footer
- remove visible fixture labels such as `Timer snooze` and preserve the white button treatment through hover, loading, and confirmation
- suppress nested `Agent` tool cards in dense queue messages so the existing flat live-child row is the only sub-agent surface there; full thread transcripts retain Agent prompt history

## Verification

- `pnpm --filter @fray-ui/web test -- awaitingPresentation.test.ts FenceCard.test.ts snooze.test.ts duration.test.ts`
- `pnpm --filter @fray-ui/web typecheck`
- `pnpm --filter @fray-ui/web build`
- `pnpm typecheck`
- `pnpm test` (`1566` pass, `0` fail, `9` skip)
- `node scripts/set-version.ts --check`
- `node scripts/sync-portable-monitors.mjs --check`
- `node --test monitors/*.test.mjs` (`16` pass)
- real Chromium QA at desktop and 390px widths for idle, hover, loading, confirmed, and dense queue-agent states; zero console, page, or failed-request errors
- independent fresh-context review completed with no remaining actionable findings

## Evidence

Screenshots are retained under `.fray/evidence/103084b9-a85e-4c70-b774-614f23f1a394/` in the local workspace.
