### PR TITLE
fix(scheduler): the sign-off nudge's cap is spent at send, and a failed turn is not a rest

### DIFF
--- a/packages/server/src/backend/types.ts
+++ b/packages/server/src/backend/types.ts
@@ -105,6 +105,7 @@ export interface NormalizedTail {
   bgShells: BgShellView[] // codex: always [] (codex has no background-shell tool)
   pendingAsk?: PendingAskData // codex: undefined
   authFault?: "authentication_rejected" // runtime provider-auth rejection (see FoldState.authFault)
+  apiFault?: boolean // the final assistant record is a synthetic API-ERROR record (see FoldState.apiFault)
   limitFault?: LimitFault // subscription window exhausted mid-turn (see FoldState.limitFault)
   contextTokens?: number // tokens the last request carried (see FoldState.contextTokens)
   contextWindow?: number // the model's context size, provider-reported (see FoldState.contextWindow)
@@ -169,6 +170,16 @@ export interface FoldState {
   // proves the credential works). Only this typed category ever leaves the fold; raw error/terminal
   // text stays out of persisted state.
   authFault?: "authentication_rejected"
+  // THE TURN NEVER REACHED THE MODEL, whatever the reason. The GENERAL case of the two faults either
+  // side of it: set whenever the backend records a synthetic API-error response, cleared by the next
+  // real assistant text, on exactly authFault's lifecycle. It exists because the specific classifiers
+  // recognise only two categories — an auth rejection by its text, a usage limit by its structured
+  // `error:"rate_limit"` — so every OTHER API error (a 400 for a context window the conversation has
+  // outgrown, a 500, a transport failure) was indistinguishable from the agent taking a turn and
+  // resting. Anything that treats "the agent spoke last" as "the agent rested" needs this, or it
+  // re-prompts a thread whose every turn is failing. Boolean because the discipline of this fold is
+  // that raw provider text never leaves it, and no consumer needs more than the fact.
+  apiFault?: boolean
   // Subscription usage-limit pause (auto-resume). Set when the backend records a limit stop — for
   // Claude the synthetic record carrying the structured `error:"rate_limit"` category, never a text
   // match — and cleared by the next real assistant text OR any user record. That clearing rule is

--- a/packages/server/src/scheduler.ts
+++ b/packages/server/src/scheduler.ts
@@ -1506,6 +1506,16 @@ export function createScheduler(deps: SchedulerDeps): Scheduler {
       // a fenceless rest and satisfies every guard above. Teaching it to sign off cannot help — it never
       // reached the model.
       if (tele.authFault) continue
+      // AND THE GENERAL CASE OF IT, which the auth guard above is one instance of. A FAILED TURN IS NOT A
+      // REST: a synthetic API-error record is written as an assistant record, so it advances the rest
+      // instant and satisfies every guard above, and a thread whose every turn fails therefore presents
+      // as an agent that keeps resting without a fence. The nudge cannot be answered — nothing the agent
+      // writes reaches the model — so it is pure burn, and on the error this matters most for it is
+      // WORSE than pure burn: a 400 for a conversation that has outgrown the model's context window is
+      // made permanent by anything that appends to the conversation, which is exactly what the nudge
+      // does. Observed unbounded in the field before the cap was fixed to bind at all; both fixes are
+      // needed, because the cap alone still spends two deliveries on a thread that can never use them.
+      if (tele.apiFault) continue
       // ANY fence means the thread already said where it stands — including `awaiting`, which is still
       // a legitimate sign-off until the registry replaces it. Nothing to teach, AND the allowance comes
       // back: signing off is the only event that proves the nudge worked, and the only one frizz cannot
@@ -2544,6 +2554,15 @@ export function createScheduler(deps: SchedulerDeps): Scheduler {
       if (runtime !== "unknown") {
         const sentAt = now()
         if (outbox.markSent(item.id, deliveryOwner, sentAt, sentAt + confirmGraceMs)) {
+          // THE NUDGE'S CAP IS SPENT AT SEND, not at confirmation, and this branch is why the cap
+          // existed on paper only. Every wake to a live runtime leaves here, so the settle below was
+          // unreachable in production — and the confirm path this hands to cannot make up for it,
+          // because `deliveryContext` reads a signoff item as SUPERSEDED the instant the agent's next
+          // assistant record lands (an API-error record is one), and the superseded branch counts
+          // nothing. `signoff_nudges` therefore stayed 0 forever while SIGNOFF_NUDGE_MAX was 2.
+          // Counting here is also the honest anchor: the tokens are spent when the message is sent,
+          // and confirmation is exactly what a thread failing every turn can never supply.
+          settleSignoffNudge(item)
           log(`waker: sent ${item.slug} — ${item.reason}; confirming within ${Math.round(confirmGraceMs / 1000)}s`)
           checkpoint("after-delivery", item)
           continue

--- a/packages/server/src/signoff-nudge.test.ts
+++ b/packages/server/src/signoff-nudge.test.ts
@@ -14,7 +14,13 @@ import { createStorage, type SessionRow } from "./storage.ts"
 import type { SessionTelemetry, Tailer } from "./tailer.ts"
 import { createScheduler } from "./scheduler.ts"
 
-function nudger(tele: Partial<SessionTelemetry>, opts: { setting?: string } = {}) {
+// `runtime` is opt-in because it changes which delivery path the scheduler takes, and the difference is
+// load-bearing rather than cosmetic. With it absent — the shape every test below it was written in —
+// `deliverDue` cannot tell whether the worker is alive, so it falls through to the acknowledge-and-settle
+// path. In PRODUCTION the runtime is always knowable, so the sent-and-confirm-later path is the only one
+// that ever runs. A cap that is only spent on the path tests take is not a cap; see the two tests at the
+// bottom of this file.
+function nudger(tele: Partial<SessionTelemetry>, opts: { setting?: string; runtime?: "alive" | "dead" } = {}) {
   const dir = mkdtempSync(join(tmpdir(), "frizz-signoff-"))
   const storage = createStorage(join(dir, "ui.db"))
   const slug = "resting"
@@ -38,6 +44,7 @@ function nudger(tele: Partial<SessionTelemetry>, opts: { setting?: string } = {}
       }),
     } as unknown as Tailer,
     resume: async (_slug, message) => { delivered.push(message) },
+    ...(opts.runtime ? { wakeRuntimeState: () => opts.runtime! } : {}),
     log: () => {},
   })
   // THE NUDGE'S OWN DELIVERIES. `delivered` is every wake the scheduler sent, and an awaiting fence
@@ -239,6 +246,68 @@ test("an auth-faulted thread is never re-prompted — the nudge cannot fix a sig
     assert.deepEqual(h.delivered, [])
   } finally { h.close() }
 })
+
+// ---- A FAILED TURN IS NOT A REST ------------------------------------------------------------------
+// The loop this file's cap was always meant to stop, reached anyway — twice over, and each half is
+// enough on its own. Measured in the field on two real threads before either was fixed: ~5,700 and
+// ~5,200 nudges to single sessions, one every ~10s (the scheduler's tick) without pause, until both
+// transcripts passed 80 MB and every turn failed with `400 invalid_request` because the conversation
+// had outgrown the model's context window. `signoff_nudges` read 0 on both rows throughout, against a
+// SIGNOFF_NUDGE_MAX of 2.
+//
+//   THE CAP WAS NEVER SPENT. Every wake to a live runtime leaves `deliverDue` at the sent-and-confirm
+//   branch, which did not settle the nudge, and the confirm that would have settled it later never ran:
+//   `deliveryContext` reads a signoff item as SUPERSEDED as soon as the agent's next assistant record
+//   lands, and superseding counts nothing. A synthetic API-error record IS an assistant record, so the
+//   failing turn that provoked the nudge is also what stopped the nudge being counted.
+//
+//   AND THE REST WAS NEVER REAL. That same record advances `lastAssistantAt`, so each failure minted a
+//   fresh rest instant, hence a fresh delivery id, defeating the per-rest dedupe as well.
+test("a nudge to a LIVE runtime is counted against the cap, not just one to an unknown one", async () => {
+  let spokeAt = "2026-08-12T00:01:00.000Z"
+  const h = nudger({
+    lastUserAt: "2026-08-12T00:00:00.000Z",
+    get lastAssistantAt() { return spokeAt },
+    get lastActivityAt() { return spokeAt },
+  } as Partial<SessionTelemetry>, { runtime: "alive" })
+  try {
+    for (let i = 2; i <= 6; i++) {
+      await h.s.tick()
+      spokeAt = `2026-08-12T00:0${i}:00.000Z`
+    }
+    assert.equal(h.delivered.length, 2, "five fenceless rests to a live worker still spend exactly the cap")
+    assert.equal(h.storage.getSession(h.slug)?.signoff_nudges, 2)
+  } finally { h.close() }
+})
+
+// The guard the cap should never have to be the last line of defence for. A thread failing every turn
+// cannot answer a reminder — nothing it writes reaches the model — and on a context-window 400 the
+// reminder is what keeps the conversation over the limit, so even the two the cap allows are two too
+// many. Both faults are pinned: the one frizz already classified, and the one it could not see at all.
+for (const [what, tele] of [
+  ["a terminal 400 the classifiers do not recognise", { apiFault: true }],
+  ["a rate limit, which also never reached the model", { apiFault: true, limitFault: { window: "5h", at: "2026-08-12T00:01:00.000Z" } }],
+] as Array<[string, Partial<SessionTelemetry>]>) {
+  test(`${what} is a failed turn, not a rest, so nothing is injected`, async () => {
+    let spokeAt = "2026-08-12T00:01:00.000Z"
+    const h = nudger({
+      lastUserAt: "2026-08-12T00:00:00.000Z",
+      get lastAssistantAt() { return spokeAt },
+      get lastActivityAt() { return spokeAt },
+      ...tele,
+    } as Partial<SessionTelemetry>, { runtime: "alive" })
+    try {
+      // Every tick is a fresh failed turn, which is exactly what defeated the per-rest dedupe: the
+      // error record is an assistant record, so it moves the rest instant every time.
+      for (let i = 2; i <= 21; i++) {
+        await h.s.tick()
+        spokeAt = `2026-08-12T00:${String(i).padStart(2, "0")}:00.000Z`
+      }
+      assert.deepEqual(h.delivered, [], "twenty consecutive failed turns produce no nudges at all")
+      assert.equal(h.storage.getSession(h.slug)?.signoff_nudges, 0)
+    } finally { h.close() }
+  })
+}
 
 // ---- THE TWO-DELIVERY INTERACTION -----------------------------------------------------------------
 // Separating the reminder from the Goal (2026-08-12) means a thread WITH a Goal now has two sources

--- a/packages/server/src/storage.ts
+++ b/packages/server/src/storage.ts
@@ -569,7 +569,8 @@ export interface Storage {
   // `resetSignoffNudges` when the thread signs off, and by nothing else. It used to reset whenever a
   // supplied anchor changed, which was wrong twice over: anchored on the human's last word, frizz's own
   // delivery (a user record) reset it; anchored on the rest, every new rest reset it. Either way the cap
-  // never bit. `anchor` is kept as the last-nudged delivery id, for diagnosis only.
+  // never bit. `anchor` is the delivery id being counted, and counting the SAME one twice is a no-op —
+  // one rest yields one delivery id, so a repeat is always a double count rather than a second rest.
   countSignoffNudge(slug: string, anchor: string | null): void
   // Give the allowance back. Called when the thread SIGNS OFF — the only event that proves the nudge
   // worked, and the only one frizz cannot cause by nudging.
@@ -1557,11 +1558,15 @@ export function createStorage(dbPath: string): Storage {
     WHERE id = ? AND state = 'armed'
   `)
   const delThreadTimers = db.prepare("DELETE FROM thread_timer WHERE thread_slug = ?")
-  // ONE statement decides reset-vs-increment, by reading the row's own anchor: SQLite evaluates the SET
-  // list against the pre-update values, so a changed anchor restarts the count at 1 in the same write.
+  // IDEMPOTENT PER ANCHOR, which is what `settleSignoffNudge` has always claimed ("a retry of the same
+  // delivery cannot count twice while a genuinely new fenceless rest does") and what the statement did
+  // not do — it incremented unconditionally. That gap was harmless only while exactly one call site
+  // counted; a nudge is now counted when it is SENT, and the confirm path that runs later for the same
+  // item would otherwise count it a second time. `IS NOT` rather than `<>` so a NULL anchor (a fresh row,
+  // or one just cleared by `resetSignoffNudges`) still counts.
   const countNudgeStmt = db.prepare(`
     UPDATE session SET signoff_nudges = signoff_nudges + 1, signoff_nudge_anchor = ?
-    WHERE slug = ?
+    WHERE slug = ? AND signoff_nudge_anchor IS NOT ?
   `)
   const resetNudgesStmt = db.prepare(`
     UPDATE session SET signoff_nudges = 0, signoff_nudge_anchor = NULL
@@ -2214,7 +2219,7 @@ export function createStorage(dbPath: string): Storage {
       recurringStmt.run(...recurringArgs(write), slug, sessionId, generation).changes === 1,
     setRecurringPromptBySlug: (slug, write) =>
       recurringBySlugStmt.run(...recurringArgs(write), slug).changes === 1,
-    countSignoffNudge: (slug, anchor) => void countNudgeStmt.run(anchor, slug),
+    countSignoffNudge: (slug, anchor) => void countNudgeStmt.run(anchor, slug, anchor),
     resetSignoffNudges: (slug) => void resetNudgesStmt.run(slug),
     countParkBump: (slug, anchor) => void countParkBumpStmt.run(anchor, slug),
     resetParkBumps: (slug) => void resetParkBumpsStmt.run(slug),

--- a/packages/server/src/tailer.ts
+++ b/packages/server/src/tailer.ts
@@ -1732,6 +1732,17 @@ export function applyRecord(state: TailState, rec: Record): void {
     } else if (raw !== undefined) {
       state.authFault = undefined
     }
+    // The SAME channel read at its most general: this record is a failed turn, whatever category it
+    // falls into. The two classifiers around it are deliberately narrow, so an error that is neither an
+    // auth rejection nor a rate limit used to leave no trace at all — and a synthetic error record still
+    // advances `lastAssistantAt` above, which is what makes a permanently failing thread look to every
+    // consumer like an agent resting after a turn. Cleared by the next real assistant text, exactly as
+    // authFault is: a genuine response is proof the turn reached the model.
+    if (rec.isApiErrorMessage === true) {
+      state.apiFault = true
+    } else if (raw !== undefined) {
+      state.apiFault = undefined
+    }
     // Subscription usage-limit classifier (auto-resume): the SAME synthetic-record channel, keyed on
     // the structured `error:"rate_limit"` category rather than any text match. The limit is what cut
     // this turn off mid-work, so the fault standing on the tail IS "this agent was running when the
@@ -4601,7 +4612,7 @@ export function createTailer(deps: TailerDeps): Tailer {
       // agent. The board reports both, and `boardRuntime` decides which one the row is allowed to draw.
       const pendingQuestion = s.lastAssistantHasQuestion
       const nowMs = now()
-      return { turn: s.turn, permPrompt: s.permPrompt, permPolicy: s.permPolicy, permDenies: s.permDenies, model: s.model, effort: s.effort, profileAt: s.profileAt, profileRevision: s.profileRevision, permissionMode: s.permissionMode, permissionModeAt: s.permissionModeAt, permissionModeRevision: s.permissionModeRevision, lastActivityAt: s.lastActivityAt, lastAssistantAt: s.lastAssistantAt, lastAssistant: s.lastAssistant, aiTitle: s.aiTitle, customTitle: s.customTitle, customTitleRevision: s.customTitleRevision, subAgents: subAgentViews(s, nowMs), droppedReports: [...s.queuedReports.values()], bgShells: [...bgShellViews(s), ...codexBgShellViews(s)], retiredShells: retiredShellViews(s), pendingAsk: s.pendingAsk, pendingQuestion, lastAssistantAllDone: s.lastAssistantAllDone, lastUserAt: s.lastUserAt, lastUserText: s.lastUserText, firstUserText: s.firstUserText, lastFence: s.lastFence, noTranscript: s.noTranscript, authFault: s.authFault, limitFault: s.limitFault, contextTokens: s.contextTokens, contextWindow: s.contextWindow, lastCompactionAt: s.lastCompactionAt }
+      return { turn: s.turn, permPrompt: s.permPrompt, permPolicy: s.permPolicy, permDenies: s.permDenies, model: s.model, effort: s.effort, profileAt: s.profileAt, profileRevision: s.profileRevision, permissionMode: s.permissionMode, permissionModeAt: s.permissionModeAt, permissionModeRevision: s.permissionModeRevision, lastActivityAt: s.lastActivityAt, lastAssistantAt: s.lastAssistantAt, lastAssistant: s.lastAssistant, aiTitle: s.aiTitle, customTitle: s.customTitle, customTitleRevision: s.customTitleRevision, subAgents: subAgentViews(s, nowMs), droppedReports: [...s.queuedReports.values()], bgShells: [...bgShellViews(s), ...codexBgShellViews(s)], retiredShells: retiredShellViews(s), pendingAsk: s.pendingAsk, pendingQuestion, lastAssistantAllDone: s.lastAssistantAllDone, lastUserAt: s.lastUserAt, lastUserText: s.lastUserText, firstUserText: s.firstUserText, lastFence: s.lastFence, noTranscript: s.noTranscript, authFault: s.authFault, apiFault: s.apiFault, limitFault: s.limitFault, contextTokens: s.contextTokens, contextWindow: s.contextWindow, lastCompactionAt: s.lastCompactionAt }
     },
     // The CURRENT fresh foreign session ids (mtime within FOREIGN_FRESH_MS, capped), mtime-desc. Kept
     // as the last scan's result — recomputed at most every FOREIGN_SCAN_EVERY ticks.


### PR DESCRIPTION
## The symptom

Two Claude Code threads driven by frizz became permanently stuck answering `Prompt is too long`. Each had accumulated **~5,700 and ~5,200 copies of the sign-off nudge** in its own transcript — one arriving every ~10s, the scheduler's tick, for roughly two days without pause. The reminder was ~93% of one session's entire context. Both session files passed **80 MB**; estimated context ran to **multiple millions of tokens against a 1M ceiling**. Neither thread could ever recover on its own, because the thing making the conversation too long was frizz appending to it.

`SIGNOFF_NUDGE_MAX` is 2. `signoff_nudges` read **0** on both rows the entire time.

The threads had to be repaired by hand (pruning the transcripts). Auto-compaction does not rescue this: it runs and succeeds, but the reduction per pass collapses as the injected text comes to dominate the window, so it cannot outrun an uncapped injection.

**This is a counting bug, not a retry-policy bug.** frizz never decides to retry anything here — I want to be precise about that, because "harness retries a terminal 400 as if it were transient" is the natural guess and it is wrong. There is no retry. There are two independent defects that combine into an unbounded loop, and each is enough on its own.

## Mechanism

### 1. The cap is never spent

`settleSignoffNudge` (`packages/server/src/scheduler.ts:1570`) is the only thing that increments the counter. `deliverDue` calls it at line 2569 — **after `outbox.acknowledge`**, on the tail of the function.

That tail is only reached when `deps.wakeRuntimeState` cannot say whether the worker is alive. When it can, the send leaves earlier, at the `markSent` branch (`scheduler.ts:2543-2551`), which `continue`s without counting. In production the runtime is always knowable, so this is the only path a nudge ever takes. Server logs confirm it directly — every nudge logged `waker: sent … confirming within 60s`, which is printed at line 2547 and nowhere else, and effectively none logged `waker: delivered … rested without signing off`.

**The confirm that would have settled it later never arrives**, and this is the non-obvious part. `reconcileOutbox` does call `settleSignoffNudge` at line 2418, but only after `deliveryContext` has been consulted first — and for a signoff item that check is:

```ts
if (isSignoffFenceId(item.fenceId)) {
  if (item.fenceId !== signoffFenceId(tele.lastAssistantAt ?? "")) return "superseded"
```

(`scheduler.ts:1105`) The fence id is minted from the rest instant. The moment the agent produces any new assistant record, `tele.lastAssistantAt` moves, the ids no longer match, and the item is superseded at line 2397 — a branch that settles snoozes and nothing else.

A synthetic API-error record **is** an assistant record (`tailer.ts:1691` sets `lastAssistantAt` from it unconditionally, before any error classification). So the failing turn that provokes the nudge is also precisely what stops the nudge from ever being counted. The counter cannot advance, so the cap at line 1534 never binds.

This held in tests only because the test harness omits `wakeRuntimeState`, so every existing test took the acknowledge path that production does not.

### 2. A failed turn is indistinguishable from a rest

The fold classifies exactly two kinds of API error: an auth rejection, by its text, and a usage limit, by its structured `error:"rate_limit"` category (`tailer.ts:1730` and `1741`). Everything else — a 400 for a context window the conversation has outgrown, a 500, a dropped connection — **leaves no trace on the telemetry at all**.

So `evalSignoffNudges` (`scheduler.ts:1485`) sees an ordinary bare rest: turn idle, agent spoke last, no fence, no auth fault. Its only API-error guard is `if (tele.authFault) continue` at line 1508. It then mints a fence id from the error record's timestamp, which makes the delivery id unique, so the per-rest dedupe (`if (outbox.get(deliveryId)) continue`) never fires either.

**frizz currently cannot see a `400` at all.** A `429` is at least classified into `limitFault` and handled by a bounded blind-retry ladder; every other API error falls through every guard.

Ten seconds later, all of it repeats.

### Repro, generically

A session whose turns fail with a terminal API error — e.g. `400 invalid_request` once the conversation exceeds the model's context window — is nudged once per scheduler tick, indefinitely, with the counter pinned at 0. Nothing about the reporting environment is needed to reproduce it.

## Evidence

Measured on two real sessions (call them A and B), read out of their transcripts and the server's own log and database:

| | session A | session B |
|---|---|---|
| nudge records injected | 5,749 | 5,167 |
| median gap between them | 10.002 s | 10.002 s |
| `signoff_nudges` on the row | 0 | 0 |
| session file at repair time | 86 MB | 82 MB |

`tickMs` defaults to `10_000` (`scheduler.ts:958`), which is exactly the observed cadence — the loop is running once per tick with nothing damping it.

The error class shifted partway through, and the flood tracks it precisely: across the whole window session B logged **39 `rate_limit` errors spread over roughly two days**, then **5,151 consecutive `invalid_request` / "Prompt is too long"** once the conversation outgrew the window. The nudge flood begins with that transition, not before it — the transient errors were self-limiting, the terminal one was not.

The server log for the same window shows the scheduler's side of it: 5,626 and 5,527 `waker: queued … rested without signing off` lines for the two threads, against single-digit counts for every other thread on the board.

## What I changed

- **`settleSignoffNudge` moves into the `markSent` branch** — the cap is spent at send, which is where the tokens are actually spent. Confirmation is exactly what a thread failing every turn can never supply, so it is the wrong event to hang a cap on.
- **`countSignoffNudge` becomes idempotent per anchor.** This is what `settleSignoffNudge`'s own comment has always claimed ("a retry of the same delivery cannot count twice while a genuinely new fenceless rest does") and what the statement did not do — it incremented unconditionally. Harmless while one call site counted; not once the later confirm path can see the same item.
- **`FoldState.apiFault`** — the general case of the two faults either side of it, set on any synthetic API-error record and cleared by the next real assistant text, on exactly `authFault`'s lifecycle. Boolean, because the fold's discipline is that raw provider text never leaves it.
- **`evalSignoffNudges` holds on it**, beside the `authFault` guard it generalises.

Both halves are needed. The cap alone still spends two deliveries on a thread that can never use them, and on a context-window 400 those two are two too many. The guard alone leaves the cap broken for genuine bare rests.

## Tests

Three new tests in `signoff-nudge.test.ts`, **all of which fail against current `main`**:

- a nudge to a **live** runtime is counted against the cap — 5 nudges instead of 2 before the fix;
- twenty consecutive failed turns produce **no** nudge at all, for a terminal 400;
- and the same for a rate limit.

The harness grows an opt-in `runtime` option so the production delivery path is reachable from a test at all — that gap is why this shipped.

## Verification

- `nub run typecheck` — clean.
- `nub run test` on the files touching this change and its consumers — **715 tests, 0 failures** (`signoff-nudge`, `storage`, `scheduler`, `tailer`, `tailer.nudge`, `recurring-prompt`, `declared-park`, `thread-timers`, `delivery-ledger`, `delivery-ledger.storage`, `board`, `board-delta`, `awaiting-watch.e2e`, `rpc-contract`, `context.claude-wake`, `context.codex-wake`, `transcript`, `resume`).
- **I could not run the full suite to completion**, and want to flag that rather than imply a green run: `nub run test` terminates early without printing a summary in my environment. It does the same on a pristine checkout of `main`, and on pristine `main` it also reports 7 failures in `packages/shared/src/receipt-bus.test.ts` — a package this PR does not touch, and those same 7 fail identically with and without my changes. I have not investigated further.

## What is confirmed vs inferred

Everything about the mechanism above is confirmed by reading `main` at 0.8.1 — the line references are to that source. The field measurements come from a deployment running the published 0.8.1; I first located the code path in that build's bundled `dist/`, then re-confirmed the identical structure in source before writing anything. That the deployment took the `markSent` branch is not an inference from the bundle: the `waker: sent … confirming within` log line is emitted from that branch only.

I have **not** reproduced the multi-day accumulation end-to-end against a live provider; the tests pin the mechanism at the scheduler and fold level.

## One question, deliberately out of scope

Three other passes guard on `authFault` with the same shape (`scheduler.ts:1508`, `1610`, `2100`, `2276`) — notably the recurring prompt's at-rest trigger, which re-prompts on the same "the agent spoke last" reading. They look like they want the same `apiFault` guard for the same reason, but that is a behaviour change to triggers this incident did not exercise, so I have left them alone rather than widen the diff. Happy to follow up if you want it.

## Operator note

While this was live, the only remedy was the `signoffNudge` = `off` setting, which silences the feature on every thread rather than the one that is looping.
