### PR TITLE
fix(web): the pinned band is the human's ask, and every renderer that holds it has a ceiling

### DIFF
--- a/packages/web/src/components/ChatView.tsx
+++ b/packages/web/src/components/ChatView.tsx
@@ -3018,6 +3018,74 @@ function useStickyCollapse(sticky: boolean | undefined, padY: string, boundedRef
   }
 }
 
+// THE PICTURES SHARE THE PIN'S CEILING — the half of a pinned ask that `useStickyCollapse` cannot
+// reach. It bounds the box it CAPS, and for a bubble that box is the prose alone: attachments are the
+// bubble's SIBLINGS, outside it (see the collapse note on the thumbnail row below). Collapsed they are
+// already handled, as one non-wrapping row of thumbnails. It is the EXPANDED state the ceiling never
+// covered, because each picture returns to FRAMED_IMAGE's flat `max-h-[420px]` and they STACK: measured
+// at 1400px wide with three screenshots, hovering the pinned ask opened the band to 1035px — 101.7% of
+// a 1000px window and 145.4% of a 700px one. A pinned element taller than the window, hiding the whole
+// transcript behind it, is the defect this band exists to prevent (maintainer 2026-08-25: "if there's
+// images, we should make sure to shrink up the images, so when you scroll, they don't cover the whole
+// screen"), and a ceiling that stops at the prose only half-keeps that promise.
+//
+// So the expanded pictures SPLIT what the ceiling leaves them, rather than scrolling inside it. Each is
+// still never taller than the 420px it renders at everywhere else, so one picture is unchanged and only
+// a stack is touched: measured at a 1000px viewport, three screenshots go from 297px each to 241px and
+// six to 110px, while one and two are left exactly where they were (they already fit). A
+// scroll region was the other option and is worse twice over — it hides the very thing hovering is FOR,
+// and it takes the wheel from the transcript for as long as the pointer rests on the band.
+//
+// Both quantities are READ OFF THE BOX. The budget is the ceiling minus everything in the message that
+// is not this column, so the prose's own share is whatever it actually took; the column's non-picture
+// height (the gaps, and each frame's border and mat) is measured rather than restated, so no constant
+// here can drift from ImageFrame's. Convergence is one pass, not a loop: shrinking the pictures changes
+// neither of them.
+//
+// THE FLOOR IS A DELIBERATE HOLE IN THE CEILING, and it is the only one. An ask whose PROSE alone
+// spends the whole 85vh leaves the pictures a budget of nothing, and the alternative to a floor is a
+// picture the human attached rendering at zero height. So they fall back to what they already show
+// collapsed and the message runs over: measured at a 1000px viewport with a 3804px ask and three
+// screenshots, 180% of the window before this hook and 120% after — improved, not fixed, in the
+// one case where nothing here can fix it. The ordinary shape of the defect, a SHORT ask carrying
+// screenshots, is the one that lands at 85% exactly.
+const PINNED_IMAGE_FLOOR = 96 // = the collapsed row's max-h-24; the pictures never expand to LESS than they collapse to
+function usePinnedImageCeiling(
+  sticky: boolean | undefined,
+  wrapperRef: { readonly current: HTMLElement | null },
+  columnRef: { readonly current: HTMLElement | null },
+) {
+  const [perImage, setPerImage] = useState<string | null>(null)
+  const measure = useCallback(() => {
+    const wrap = wrapperRef.current, col = columnRef.current
+    if (!sticky || !wrap || !col) return setPerImage(null)
+    const images = [...col.querySelectorAll("img")]
+    if (images.length === 0) return setPerImage(null)
+    const colH = col.getBoundingClientRect().height
+    const ceiling = Math.round((typeof window === "undefined" ? 800 : window.innerHeight) * 0.85)
+    const budget = ceiling - (wrap.getBoundingClientRect().height - colH)
+    const chrome = colH - images.reduce((h, img) => h + img.getBoundingClientRect().height, 0)
+    setPerImage(`${Math.max(PINNED_IMAGE_FLOOR, Math.floor((budget - chrome) / images.length))}px`)
+  }, [sticky, wrapperRef, columnRef])
+  useLayoutEffect(() => { measure() })
+  // A picture has no height until it LOADS, and loading re-renders nothing — so the column is observed
+  // rather than only measured on render. The same observer covers expand/collapse and a width change.
+  useEffect(() => {
+    const col = columnRef.current
+    if (!col || typeof ResizeObserver === "undefined") return
+    const ro = new ResizeObserver(() => measure())
+    ro.observe(col)
+    return () => ro.disconnect()
+  }, [measure, columnRef])
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    const onResize = () => measure()
+    window.addEventListener("resize", onResize)
+    return () => window.removeEventListener("resize", onResize)
+  }, [measure])
+  return perImage
+}
+
 // The user chat bubble, right-justified. When `sticky` (the pinned most-recent ask), it COLLAPSES: a
 // fully-rounded four-line card whose text FADES into the bubble colour near the bottom (no hard clip, no
 // ellipsis) with a soft "there's more" cue, and whose ATTACHMENTS drop to a row of thumbnails; hovering
@@ -3026,6 +3094,9 @@ function useStickyCollapse(sticky: boolean | undefined, padY: string, boundedRef
 // Its own component so the sticky hover/measure hooks stay out of memoized Message.
 function UserBubble({ text, rawText, queued, sticky, deliveryUnconfirmed, deliveryId, sourceId }: { text: string; rawText?: string; queued?: boolean; sticky?: boolean; deliveryUnconfirmed?: boolean; deliveryId?: string; sourceId?: string }) {
   const { ref, collapsed, overflows, maxH, scrollable, reserveGutter, handlers, onCapTransitionEnd } = useStickyCollapse(sticky, "1.5rem") // py-3
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const imageColRef = useRef<HTMLDivElement>(null)
+  const pinnedImageMax = usePinnedImageCeiling(sticky, wrapRef, imageColRef)
   // TAKE IT BACK. A still-queued send is the one bubble in the transcript that isn't history yet, so
   // it alone is clickable: the click unqueues it at the provider and hands the words back to the
   // prompt box (see lib/unqueueFollowUp.ts). Three gates, all of them load-bearing:
@@ -3071,7 +3142,7 @@ function UserBubble({ text, rawText, queued, sticky, deliveryUnconfirmed, delive
     // render outside it, on the dark page — see the row below). Hung on the bubble, moving the pointer
     // onto a pinned screenshot collapsed the very thing you were reaching for, and the picture — the
     // biggest thing in the band — could never be expanded by pointing at it.
-    <div data-frizz-msg={sourceId} {...handlers} className="self-end flex flex-col items-end gap-0.5 max-w-[85%]">
+    <div ref={wrapRef} data-frizz-msg={sourceId} {...handlers} className="self-end flex flex-col items-end gap-0.5 max-w-[85%]">
       {/* OFF-WHITE bubble, BLACK text — the human's words POP against the dark page + agent prose. bg-user-bubble
           is a tick less white than bg-fg so it reads as a card. whitespace-pre-wrap is load-bearing: user text
           is verbatim, so its line breaks must survive. Skipped entirely for an attachment-only send, so the
@@ -3166,9 +3237,10 @@ function UserBubble({ text, rawText, queued, sticky, deliveryUnconfirmed, delive
               intrinsic width when there are more than the band is wide — which is what makes the cost
               of N pictures one band of height at ANY width, rather than N. Measured in a 403px-wide
               drawer band: one thumb 96px tall, two 89px, three 57px, and the whole collapsed ask 242px
-              → 203px as pictures are added. Expanded, the clamp lifts and the column returns — the
-              pictures go back to exactly the size they render at everywhere else, which is what
-              hovering is FOR.
+              → 203px as pictures are added. Expanded, the row becomes the column again and each picture
+              grows back toward the size it renders at everywhere else — bounded by what the pin's own
+              ceiling leaves them, so a stack of screenshots cannot do on hover what the thumbnails stop
+              it doing on scroll (usePinnedImageCeiling).
               `flex-wrap` was the first attempt and it is a trap here: the max-content size of a MULTI-LINE
               flex container is its widest ITEM, not the sum of them, so inside this shrink-to-fit column
               the row collapsed to one thumb's width and every picture took its own line — three
@@ -3181,10 +3253,12 @@ function UserBubble({ text, rawText, queued, sticky, deliveryUnconfirmed, delive
               level with the collapsed bubble, so a collapsed ask reads as one band rather than two. */}
           {attachments.some((a) => a.kind === "image") && (
             <div
+              ref={imageColRef}
+              style={pinnedImageMax ? ({ "--pin-img-max": pinnedImageMax } as CSSProperties) : undefined}
               className={`flex gap-1.5 ${
                 collapsed
                   ? "max-w-full flex-row flex-nowrap justify-end [&>*]:min-w-0 [&_img]:max-h-24"
-                  : "flex-col items-end"
+                  : `flex-col items-end ${pinnedImageMax ? "[&_img]:max-h-[var(--pin-img-max)]" : ""}`
               }`}
             >
               {attachments.filter((a) => a.kind === "image").map((a, i) => <BlockImage key={`i${i}-${a.path}`} path={a.path} hideCaption />)}

--- a/packages/web/src/components/ChatView.tsx
+++ b/packages/web/src/components/ChatView.tsx
@@ -3068,15 +3068,33 @@ function usePinnedImageCeiling(
     setPerImage(`${Math.max(PINNED_IMAGE_FLOOR, Math.floor((budget - chrome) / images.length))}px`)
   }, [sticky, wrapperRef, columnRef])
   useLayoutEffect(() => { measure() })
-  // A picture has no height until it LOADS, and loading re-renders nothing — so the column is observed
-  // rather than only measured on render. The same observer covers expand/collapse and a width change.
+  // OBSERVED, NOT ONLY MEASURED ON RENDER, and the WRAPPER is the half that matters. A picture has no
+  // height until it LOADS, and loading re-renders nothing — that is why the column is watched. The
+  // wrapper is watched because the prose beside it GROWS ON A TRANSITION: `useStickyCollapse` writes the
+  // bubble's new `max-height` in the same commit this hook's layout effect runs in, and a read taken
+  // then returns the FROM value, so the budget was struck against the collapsed prose and the pictures
+  // were handed slack that no longer existed once the tween landed. Nothing corrected it either —
+  // `onCapTransitionEnd` re-measures `useStickyCollapse`, whose setters all take the values they
+  // already hold for a bubble under the cap, so React bails and this effect never re-runs; and the
+  // bubble is the column's SIBLING, so growing produced no record on a column-only observer. Measured
+  // at 1400x1000 with the fixture's `?size=medium` ask (108px of prose collapsed, 360px expanded) and
+  // three screenshots: 1101px in a 1000px window, over by exactly the 252px the prose grew.
+  //
+  // The wrapper resizes on every frame of that tween, so the budget tracks it and the last record is
+  // the settled one. It cannot chase itself: `budget - chrome` reduces to the ceiling minus everything
+  // in the message that is not picture ink, which the picture heights cancel out of entirely.
+  //
+  // It is exact at REST and approaches from above in motion, by one frame: a resize record is read
+  // after that frame's layout, so the pictures re-cap on the next one. Frame-sampled for the case
+  // above — 849, 915, 894, 883, 875, … 851, 849 — a single 16ms frame 7.7% over, then monotone down.
+  // Removing even that would mean knowing the prose's target height before it renders, which is only
+  // available for the expand direction and not worth the second source of truth.
   useEffect(() => {
-    const col = columnRef.current
-    if (!col || typeof ResizeObserver === "undefined") return
+    if (typeof ResizeObserver === "undefined") return
     const ro = new ResizeObserver(() => measure())
-    ro.observe(col)
+    for (const el of [columnRef.current, wrapperRef.current]) if (el) ro.observe(el)
     return () => ro.disconnect()
-  }, [measure, columnRef])
+  }, [measure, columnRef, wrapperRef])
   useEffect(() => {
     if (typeof window === "undefined") return
     const onResize = () => measure()

--- a/packages/web/src/components/ChatView.tsx
+++ b/packages/web/src/components/ChatView.tsx
@@ -71,7 +71,7 @@ import { BLOCK_RADIUS, CARD_ACTION_EXPLAINER, CARD_ACTION_RADIUS, CARD_BODY, CAR
 import { QuestionBlockCard } from "./QuestionBlockCard.tsx"
 // ONE frame for every image the chat renders — border, inset mat, centered picture. See its module
 // header for why it spans the message width rather than shrink-wrapping each picture.
-import { FRAMED_IMAGE, ImageFrame } from "./ImageFrame.tsx"
+import { FRAMED_IMAGE, FRAMED_IMAGE_MAX_PX, ImageFrame } from "./ImageFrame.tsx"
 // The resting card, shared with the queue (TodosView passes it the event-Snooze; these two surfaces
 // deliberately pass no action — see the module header).
 import { AwaitingBackgroundCard, showsRestingCard } from "./AwaitingBackgroundCard.tsx"
@@ -3029,12 +3029,15 @@ function useStickyCollapse(sticky: boolean | undefined, padY: string, boundedRef
 // images, we should make sure to shrink up the images, so when you scroll, they don't cover the whole
 // screen"), and a ceiling that stops at the prose only half-keeps that promise.
 //
-// So the expanded pictures SPLIT what the ceiling leaves them, rather than scrolling inside it. Each is
-// still never taller than the 420px it renders at everywhere else, so one picture is unchanged and only
-// a stack is touched: measured at a 1000px viewport, three screenshots go from 297px each to 241px and
-// six to 110px, while one and two are left exactly where they were (they already fit). A
-// scroll region was the other option and is worse twice over — it hides the very thing hovering is FOR,
-// and it takes the wheel from the transcript for as long as the pointer rests on the band.
+// So the expanded pictures SPLIT what the ceiling leaves them, rather than scrolling inside it. Only a
+// SHRINK, which is what the clamp below is for: a budget struck from the viewport is an upper bound on
+// what the pictures may take, never a licence to take it, and a wide window hands out far more than the
+// 420px a picture draws in any other bubble. Unclamped, one 400x1200 screenshot on a pinned ask rendered
+// at 679px in a 900px-tall window and 1104px in a 1400px one, and two at 542px each — bigger pinned than
+// unpinned, which is exactly backwards. Clamped, one and two are left where they already were and only
+// a stack is touched: measured at a 1000px viewport, three go from 420px each to 241px and six to 110px.
+// A scroll region was the other option and is worse twice over — it hides the very thing hovering is
+// FOR, and it takes the wheel from the transcript for as long as the pointer rests on the band.
 //
 // Both quantities are READ OFF THE BOX. The budget is the ceiling minus everything in the message that
 // is not this column, so the prose's own share is whatever it actually took; the column's non-picture
@@ -3065,7 +3068,14 @@ function usePinnedImageCeiling(
     const ceiling = Math.round((typeof window === "undefined" ? 800 : window.innerHeight) * 0.85)
     const budget = ceiling - (wrap.getBoundingClientRect().height - colH)
     const chrome = colH - images.reduce((h, img) => h + img.getBoundingClientRect().height, 0)
-    setPerImage(`${Math.max(PINNED_IMAGE_FLOOR, Math.floor((budget - chrome) / images.length))}px`)
+    const per = Math.max(PINNED_IMAGE_FLOOR, Math.floor((budget - chrome) / images.length))
+    // NULL, not the number, once the share is at or above what the picture would have taken anyway.
+    // This hook only ever SHRINKS: a pinned ask is the one place a screenshot could otherwise render
+    // LARGER than the identical screenshot elsewhere in the app, and a budget struck from the viewport
+    // says nothing about how big a picture ought to be — a single attachment at 1400px tall was handed
+    // 1104px, against the 420px it draws in any other bubble. Standing down here returns it to
+    // FRAMED_IMAGE, which is where that decision lives; the class is only applied when it binds.
+    setPerImage(per >= FRAMED_IMAGE_MAX_PX ? null : `${per}px`)
   }, [sticky, wrapperRef, columnRef])
   useLayoutEffect(() => { measure() })
   // OBSERVED, NOT ONLY MEASURED ON RENDER, and the WRAPPER is the half that matters. A picture has no
@@ -3090,17 +3100,20 @@ function usePinnedImageCeiling(
   // Removing even that would mean knowing the prose's target height before it renders, which is only
   // available for the expand direction and not worth the second source of truth.
   useEffect(() => {
-    if (typeof ResizeObserver === "undefined") return
+    // `sticky` gates the SUBSCRIPTION, not just the measurement: `TodosView` renders every message of
+    // every queue card unvirtualized, so without it each historical bubble builds a ResizeObserver to
+    // watch a wrapper whose answer can only ever be null.
+    if (!sticky || typeof ResizeObserver === "undefined") return
     const ro = new ResizeObserver(() => measure())
     for (const el of [columnRef.current, wrapperRef.current]) if (el) ro.observe(el)
     return () => ro.disconnect()
-  }, [measure, columnRef, wrapperRef])
+  }, [sticky, measure, columnRef, wrapperRef])
   useEffect(() => {
-    if (typeof window === "undefined") return
+    if (!sticky || typeof window === "undefined") return
     const onResize = () => measure()
     window.addEventListener("resize", onResize)
     return () => window.removeEventListener("resize", onResize)
-  }, [measure])
+  }, [sticky, measure])
   return perImage
 }
 

--- a/packages/web/src/components/ChatView.tsx
+++ b/packages/web/src/components/ChatView.tsx
@@ -2847,8 +2847,12 @@ function SendMessageCard({ to, summary, body, type, status, durationMs }: { to?:
 //     ABOVE it (in the `pt-3` gap). Only `z-[9]` keeps it above the scrolling content, never masking it.
 //   • `pt-3` keeps the rounded bubble off the pane's top edge (flush rounded corners read as broken)
 //     and leaves a gap the transcript scrolls through above the floating bubble.
-//   • `max-h` + `overflow-y-auto`: a user message taller than the pane scrolls WITHIN the bubble instead
-//     of swallowing the whole viewport.
+//   • THE WRAPPER IMPOSES NO CEILING. It is transparent and unclipped by design (a scroller here would
+//     eat the wheel over the content to its left, and a clip cannot keep the collapsed bubble's rounded
+//     corners), so the height cap lives on the CHILD — see UserBubble's four-line collapse below. Every
+//     renderer that can hold the pin therefore has to cap itself, and the ones that ignore `sticky`
+//     must never reach this band: a delivered wake did, and the uncapped card FrizzWake falls back to
+//     covered the whole transcript (maintainer 2026-08-21). `lastAskIndex` is what keeps them out.
 //   • `flex flex-col` re-establishes the column so Message's `self-end` bubble stays right-aligned; the
 //     full-width transparent wrapper leaves the left region clear for content to show through.
 //   • `pointer-events-none` on the wrapper + `pointer-events-auto` on the bubble: the transparent
@@ -2860,8 +2864,8 @@ function SendMessageCard({ to, summary, body, type, status, durationMs }: { to?:
 // anchors off it) while data-transcript-sticky tells captureTranscriptViewportAnchor to skip it — a
 // pinned band has an invariant top and must never be chosen as the load-earlier scroll anchor.
 // The positioning wrapper only: sticks the floating bubble to the pane top. The HEIGHT/collapse (the
-// ~200px cap, the bottom text-fade, and hover-to-expand) live on the bubble itself (UserBubble, driven
-// by the `sticky` prop on Message) so the collapsed card stays fully rounded — a wrapper clip can't.
+// four-line cap, the bottom text-fade, and hover-to-expand) live on the pinned renderer itself, driven
+// by the `sticky` prop on Message, so the collapsed card stays fully rounded — a wrapper clip can't.
 export function StickyUserBand({ children, stickyTopPx, sourceId }: { children: ReactNode; stickyTopPx?: number; sourceId?: string }) {
   const offset = stickyTopPx !== undefined
   return (
@@ -2880,13 +2884,100 @@ export function StickyUserBand({ children, stickyTopPx, sourceId }: { children: 
   )
 }
 
-// The user chat bubble, right-justified. When `sticky` (the pinned most-recent ask), it COLLAPSES: a
-// fully-rounded ~200px card whose text FADES into the bubble colour near the bottom (no hard clip, no
-// ellipsis) with a soft "there's more" cue; hovering expands it to the full message (up to 85vh, then
-// it scrolls) and leaving re-collapses. Non-sticky (every historical bubble) is the plain, uncapped
-// bubble, unchanged. Its own component so the sticky hover/measure hooks stay out of memoized Message.
-function UserBubble({ text, rawText, queued, sticky, deliveryUnconfirmed, deliveryId, sourceId }: { text: string; rawText?: string; queued?: boolean; sticky?: boolean; deliveryUnconfirmed?: boolean; deliveryId?: string; sourceId?: string }) {
+// ---- THE PINNED ASK'S COLLAPSE ---------------------------------------------------------------------
+// How tall the pinned current ask is allowed to be at REST. The band floats over the transcript, so
+// every pixel it occupies is a pixel of the conversation you cannot read while scrolling — and unlike
+// the ask itself, which you wrote and remember, that transcript is the thing you are actually reading.
+//
+// FOUR LINES, expressed in `lh` so the browser resolves it (maintainer 2026-08-25: "cap it to like
+// three or four lines"). `1lh` is one line box of the RESOLVED font, so this tracks the prose/mono
+// setting and the type scale with nothing to re-measure when either moves — the same reason the icon
+// nudges prefer `1cap` to a fitted constant. Under the fade the last of the four reads as a hint, so
+// what you actually get is three crisp lines and a fourth dissolving, which is the ask restated rather
+// than reproduced.
+//
+// The caller supplies its OWN vertical padding, because `max-height` is a border-box measurement and
+// the two things that can hold the pin do not agree on it — the bubble is `py-3`, the answers card is
+// `p-4`. Baking the bubble's in would silently give the card three lines and a bit.
+//
+// It replaced a flat 200px, which was ~8 lines of a 14px font — half a drawer, and that was BEFORE the
+// attachments below it, which the cap never covered at all (see the image row).
+const collapsedAskMax = (padY: string) => `calc(4lh + ${padY})`
+
+// The pinned ask's collapse machinery, shared by the two things that can BE the current ask: the human's
+// bubble and their composed answers card. It lived inside UserBubble until the answers card turned out
+// to hold the pin too and to have no cap of its own — the same defect class as the scheduler wake that
+// started this, one renderer further along.
+//
+// `ref` goes on the element being capped; `handlers` go on whatever the POINTER should count as
+// hovering, which is deliberately not the same node — a bubble's attachments render outside it.
+function useStickyCollapse(sticky: boolean | undefined, padY: string) {
   const ref = useRef<HTMLDivElement>(null)
+  const [expanded, setExpanded] = useState(false)
+  const [overflows, setOverflows] = useState(false)
+  // Whether the FULL message is taller than the expanded cap (85vh) — the ONLY case that genuinely
+  // needs a scrollbar. Everything shorter expands to fit, so it stays `overflow-hidden` even when
+  // expanded: no scrollbar ever appears (not even transiently mid-animation), so no reflow. (A real
+  // scrollbar, in the exceeds-cap case, rides a reserved gutter — see scrollbar-gutter in styles.css.)
+  const [exceedsCap, setExceedsCap] = useState(false)
+  // Scrolling is enabled only AFTER the expand animation finishes. During the grow, the box stays
+  // `overflow-hidden` — otherwise it's a live scroll container whose content scrolls as it resizes
+  // (the reported "card contents scroll during expansion" bug). transitionend flips this on.
+  const [scrollReady, setScrollReady] = useState(false)
+  // Measure the real content height so max-height animates BOTH ways smoothly (a bare collapsed↔85vh
+  // transition visibly lags on collapse) and so the fade shows ONLY when the text actually overflows.
+  const [maxH, setMaxH] = useState<string | null>(null)
+  const measure = useCallback(() => {
+    const el = ref.current
+    if (!sticky || !el) { setMaxH(null); setOverflows(false); setExceedsCap(false); return }
+    const cap = Math.round((typeof window === "undefined" ? 800 : window.innerHeight) * 0.85)
+    setExceedsCap(el.scrollHeight > cap)
+    // THE OVERFLOW TEST IS READ OFF THE BOX, not computed from a line height. `clientHeight` while
+    // collapsed IS whatever `calc(4lh + …)` resolved to in this font at this size, so the fade appears
+    // exactly when there is something under it — with no second copy of the cap's arithmetic here to
+    // drift from the CSS. It is only meaningful while collapsed; expanded, the box is the content.
+    if (!expanded) setOverflows(el.scrollHeight > el.clientHeight + 1)
+    setMaxH(expanded ? `${Math.min(el.scrollHeight, cap)}px` : collapsedAskMax(padY))
+  }, [sticky, expanded, padY])
+  useLayoutEffect(() => { measure() })
+  // Re-measure on viewport resize so the 85vh cap / exceedsCap gate never go stale under a window resize.
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    const onResize = () => measure()
+    window.addEventListener("resize", onResize)
+    return () => window.removeEventListener("resize", onResize)
+  }, [measure])
+  const collapsed = sticky === true && !expanded
+  return {
+    ref,
+    collapsed,
+    overflows: collapsed && overflows,
+    maxH,
+    // Scroll ONLY when expanded, over the cap, AND the expand animation has settled.
+    scrollable: sticky === true && expanded && exceedsCap && scrollReady,
+    // Reserve the scrollbar's width in the states that lack the gutter, so the text width is identical
+    // across every state: zero reflow even for over-cap messages.
+    reserveGutter: sticky === true && exceedsCap && !(expanded && scrollReady),
+    handlers: sticky
+      ? {
+          onMouseEnter: () => setExpanded(true),
+          onMouseLeave: () => { setExpanded(false); setScrollReady(false) },
+        }
+      : {},
+    onCapTransitionEnd: sticky
+      ? (e: { propertyName: string }) => { if (e.propertyName === "max-height" && expanded && exceedsCap) setScrollReady(true) }
+      : undefined,
+  }
+}
+
+// The user chat bubble, right-justified. When `sticky` (the pinned most-recent ask), it COLLAPSES: a
+// fully-rounded four-line card whose text FADES into the bubble colour near the bottom (no hard clip, no
+// ellipsis) with a soft "there's more" cue, and whose ATTACHMENTS drop to a row of thumbnails; hovering
+// expands it to the full message (up to 85vh, then it scrolls) with the pictures back at full size, and
+// leaving re-collapses. Non-sticky (every historical bubble) is the plain, uncapped bubble, unchanged.
+// Its own component so the sticky hover/measure hooks stay out of memoized Message.
+function UserBubble({ text, rawText, queued, sticky, deliveryUnconfirmed, deliveryId, sourceId }: { text: string; rawText?: string; queued?: boolean; sticky?: boolean; deliveryUnconfirmed?: boolean; deliveryId?: string; sourceId?: string }) {
+  const { ref, collapsed, overflows, maxH, scrollable, reserveGutter, handlers, onCapTransitionEnd } = useStickyCollapse(sticky, "1.5rem") // py-3
   // TAKE IT BACK. A still-queued send is the one bubble in the transcript that isn't history yet, so
   // it alone is clickable: the click unqueues it at the provider and hands the words back to the
   // prompt box (see lib/unqueueFollowUp.ts). Three gates, all of them load-bearing:
@@ -2923,44 +3014,16 @@ function UserBubble({ text, rawText, queued, sticky, deliveryUnconfirmed, delive
   // splitProseAttachments, the agent-prose splitter) it never swallows a ::directive or mermaid line.
   // `text` itself stays whole for the unqueue payload below — restoreDraft must hand the paths back.
   const { prose, attachments } = useMemo(() => splitComposerValue(text), [text])
-  const [expanded, setExpanded] = useState(false)
-  const [overflows, setOverflows] = useState(false)
-  // Whether the FULL message is taller than the expanded cap (85vh) — the ONLY case that genuinely
-  // needs a scrollbar. Everything shorter expands to fit, so it stays `overflow-hidden` even when
-  // expanded: no scrollbar ever appears (not even transiently mid-animation), so no reflow. (A real
-  // scrollbar, in the exceeds-cap case, rides a reserved gutter — see scrollbar-gutter in styles.css.)
-  const [exceedsCap, setExceedsCap] = useState(false)
-  // Scrolling is enabled only AFTER the expand animation finishes. During the grow, the bubble stays
-  // `overflow-hidden` — otherwise it's a live scroll container whose content scrolls as it resizes
-  // (the reported "card contents scroll during expansion" bug). transitionend flips this on.
-  const [scrollReady, setScrollReady] = useState(false)
-  // Measure the real content height so max-height animates BOTH ways smoothly (a bare 200px↔85vh
-  // transition visibly lags on collapse) and so the fade shows ONLY when the text actually overflows.
-  const [maxH, setMaxH] = useState<string | null>(null)
-  const measure = useCallback(() => {
-    const el = ref.current
-    if (!sticky || !el) { setMaxH(null); setOverflows(false); setExceedsCap(false); return }
-    const cap = Math.round((typeof window === "undefined" ? 800 : window.innerHeight) * 0.85)
-    setOverflows(el.scrollHeight > 205)
-    setExceedsCap(el.scrollHeight > cap)
-    setMaxH(expanded ? `${Math.min(el.scrollHeight, cap)}px` : "200px")
-  }, [sticky, expanded])
-  useLayoutEffect(() => { measure() }, [measure, text])
-  // Re-measure on viewport resize so the 85vh cap / exceedsCap gate never go stale under a window resize.
-  useEffect(() => {
-    if (typeof window === "undefined") return
-    const onResize = () => measure()
-    window.addEventListener("resize", onResize)
-    return () => window.removeEventListener("resize", onResize)
-  }, [measure])
-  const collapsed = sticky === true && !expanded
-  // Scroll ONLY when expanded, over the cap, AND the expand animation has settled.
-  const scrollable = sticky === true && expanded && exceedsCap && scrollReady
   return (
     // `self-end` must stay on THIS node: the parent scroll container is a flex column and the bubble's
     // right-justification depends on being its direct child (see the group-container note above the
     // queued-message stack).
-    <div data-frizz-msg={sourceId} className="self-end flex flex-col items-end gap-0.5 max-w-[85%]">
+    //
+    // THE HOVER LIVES HERE, not on the bubble, because the attachments are the bubble's SIBLINGS (they
+    // render outside it, on the dark page — see the row below). Hung on the bubble, moving the pointer
+    // onto a pinned screenshot collapsed the very thing you were reaching for, and the picture — the
+    // biggest thing in the band — could never be expanded by pointing at it.
+    <div data-frizz-msg={sourceId} {...handlers} className="self-end flex flex-col items-end gap-0.5 max-w-[85%]">
       {/* OFF-WHITE bubble, BLACK text — the human's words POP against the dark page + agent prose. bg-user-bubble
           is a tick less white than bg-fg so it reads as a card. whitespace-pre-wrap is load-bearing: user text
           is verbatim, so its line breaks must survive. Skipped entirely for an attachment-only send, so the
@@ -2986,16 +3049,14 @@ function UserBubble({ text, rawText, queued, sticky, deliveryUnconfirmed, delive
               unqueue({ deliveryId: deliveryId!, text, rawText: rawText ?? text, from: e.currentTarget })
             },
           } : {})}
-          onMouseEnter={sticky ? () => setExpanded(true) : undefined}
-          onMouseLeave={sticky ? () => { setExpanded(false); setScrollReady(false) } : undefined}
-          onTransitionEnd={sticky ? (e) => { if (e.propertyName === "max-height" && expanded && exceedsCap) setScrollReady(true) } : undefined}
+          onTransitionEnd={onCapTransitionEnd}
           // While NOT scrollable (collapsed, or expanding before it settles) the bubble is `overflow-hidden`
           // and so lacks the scrollbar-gutter the scrollable state reserves — a 7px text shift when scroll
           // turns on. Reserve the SAME width (`--sbw`, the app's scrollbar width) here so the text width is
           // identical across every state: zero reflow even for over-cap messages.
           style={{
             ...(maxH ? { maxHeight: maxH } : {}),
-            ...(sticky && exceedsCap && !scrollable ? { paddingRight: "calc(0.875rem + var(--sbw))" } : {}),
+            ...(reserveGutter ? { paddingRight: "calc(0.875rem + var(--sbw))" } : {}),
           }}
           // A retractable bubble LIFTS to FULL opacity under the pointer — so the one message in the
           // transcript that is still yours to change says so on hover instead of needing a permanent
@@ -3047,7 +3108,40 @@ function UserBubble({ text, rawText, queued, sticky, deliveryUnconfirmed, delive
           noise the human already knows, and a failed load falls back to the path text anyway. */}
       {attachments.length > 0 && (
         <div className="mt-1 flex flex-col items-end gap-1.5">
-          {attachments.filter((a) => a.kind === "image").map((a, i) => <BlockImage key={`i${i}-${a.path}`} path={a.path} hideCaption />)}
+          {/* THE PICTURES COLLAPSE TOO, and this is the half the old cap never reached: attachments are
+              the bubble's SIBLINGS, so a 420px screenshot (FRAMED_IMAGE's ceiling) hung under a capped
+              bubble and floated over the transcript at full size on every scroll — the complaint that
+              reopened this (maintainer 2026-08-25: "if there's images, we should make sure to shrink up
+              the images, so when you scroll, they don't cover the whole screen").
+              Collapsed they are THUMBNAILS ON ONE ROW THAT NEVER WRAPS. `object-contain` keeps each
+              aspect, so a height clamp alone narrows them, and `min-w-0` lets them SHRINK below their
+              intrinsic width when there are more than the band is wide — which is what makes the cost
+              of N pictures one band of height at ANY width, rather than N. Measured in a 403px-wide
+              drawer band: one thumb 96px tall, two 89px, three 57px, and the whole collapsed ask 242px
+              → 203px as pictures are added. Expanded, the clamp lifts and the column returns — the
+              pictures go back to exactly the size they render at everywhere else, which is what
+              hovering is FOR.
+              `flex-wrap` was the first attempt and it is a trap here: the max-content size of a MULTI-LINE
+              flex container is its widest ITEM, not the sum of them, so inside this shrink-to-fit column
+              the row collapsed to one thumb's width and every picture took its own line — three
+              screenshots came to 474px in a 437px pane, i.e. the defect this row exists to fix. `w-full`
+              does not rescue it either, because the parent it would fill has already collapsed the same way.
+              The thumb ceiling is a flat rem, NOT the prose cap's `4lh`: `lh` inside the frame resolves
+              against the FRAME's mono type (frizz-bash), not the bubble's prose type, so the same
+              expression means two different heights in the two halves — it measured 69px here against
+              the bubble's 108px. 6rem + the frame's 14px of border and mat lands the thumb at ~110px,
+              level with the collapsed bubble, so a collapsed ask reads as one band rather than two. */}
+          {attachments.some((a) => a.kind === "image") && (
+            <div
+              className={`flex gap-1.5 ${
+                collapsed
+                  ? "max-w-full flex-row flex-nowrap justify-end [&>*]:min-w-0 [&_img]:max-h-24"
+                  : "flex-col items-end"
+              }`}
+            >
+              {attachments.filter((a) => a.kind === "image").map((a, i) => <BlockImage key={`i${i}-${a.path}`} path={a.path} hideCaption />)}
+            </div>
+          )}
           {/* Docs share one WRAPPING row (mirroring SentFilesCard) — a column would spend a whole line
               on each pill. `justify-end` keeps the run flush with the bubble's right edge. */}
           {attachments.some((a) => a.kind === "file") && (
@@ -3127,7 +3221,7 @@ export const Message = memo(function Message({ m, answering, dense, paired, stic
     // renders as a structured answers card echoing the question component — not a flat run-on bubble.
     // Non-matching text (and a parse hiccup → null) falls back to the plain bubble; text is never lost.
     const answers = paired !== undefined ? paired : parseAnswersCard(text)
-    if (answers) return <AnswersCard answers={answers} queued={m.queued} sourceId={m.sourceId} />
+    if (answers) return <AnswersCard answers={answers} queued={m.queued} sticky={sticky} sourceId={m.sourceId} />
     // A scheduler wake is recorded as a user turn because it is pasted into the worker's composer —
     // but FRIZZ wrote it, not the human, so it must not wear the human's off-white right-justified
     // bubble. `m.wake` is the server's own tell (the delivery token it stripped), never a text guess.
@@ -3348,10 +3442,20 @@ export const Message = memo(function Message({ m, answering, dense, paired, stic
 // and a second number can only COMPETE with whatever numbering the worker used inside the question text:
 // a batch answering a BURIED ask renumbers its rows from 1 (they may span several messages), so
 // answering questions 9–11 of an earlier ask rendered "1" against a question that reads "9. …".
-function AnswersCard({ answers, queued, sourceId }: { answers: PairedAnswer[]; queued?: boolean; sourceId?: string }) {
+function AnswersCard({ answers, queued, sticky, sourceId }: { answers: PairedAnswer[]; queued?: boolean; sticky?: boolean; sourceId?: string }) {
+  // THE OTHER THING THAT CAN HOLD THE PIN. A composed multi-block answer is the human's own current ask,
+  // so unlike a scheduler wake it BELONGS in the band — but it ignored `sticky` entirely and had no
+  // ceiling, so answering four questions with pasted paragraphs floated an unbounded card over the
+  // transcript. Same collapse as the bubble beside it: four lines, a fade, hover for the rest.
+  const { ref, collapsed, overflows, maxH, scrollable, reserveGutter, handlers, onCapTransitionEnd } = useStickyCollapse(sticky, "2rem") // p-4
   return (
-    <div data-frizz-msg={sourceId} data-answers-card className={`self-end flex w-full max-w-[85%] flex-col items-end ${queued ? "opacity-50" : ""}`}>
-      <div className={`w-full min-w-0 ${BLOCK_RADIUS} rounded-br-sm border border-border-strong bg-elevated p-4`}>
+    <div data-frizz-msg={sourceId} data-answers-card {...handlers} className={`self-end flex w-full max-w-[85%] flex-col items-end ${queued ? "opacity-50" : ""}`}>
+      <div
+        ref={ref}
+        onTransitionEnd={onCapTransitionEnd}
+        style={{ ...(maxH ? { maxHeight: maxH } : {}), ...(reserveGutter ? { paddingRight: "calc(1rem + var(--sbw))" } : {}) }}
+        className={`relative w-full min-w-0 ${BLOCK_RADIUS} rounded-br-sm border border-border-strong bg-elevated p-4 ${sticky ? `transition-[max-height] duration-200 ease-out ${scrollable ? "overflow-y-auto" : "overflow-hidden"}` : ""}`}
+      >
         <CardHead icon={ListChecks} label="Answers" />
         <CardContent>
           <div className="flex flex-col gap-2.5">
@@ -3378,6 +3482,11 @@ function AnswersCard({ answers, queued, sourceId }: { answers: PairedAnswer[]; q
             ))}
           </div>
         </CardContent>
+        {/* Same soft "there's more" cue the bubble wears, in THIS card's fill rather than the bubble's —
+            a hard clip on a bordered card reads as a broken card, not as a collapsed one. */}
+        {overflows && (
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-elevated to-transparent" />
+        )}
       </div>
     </div>
   )

--- a/packages/web/src/components/ChatView.tsx
+++ b/packages/web/src/components/ChatView.tsx
@@ -2918,7 +2918,11 @@ const collapsedAskMax = (padY: string) => `calc(4lh + ${padY})`
 //
 // `ref` goes on the element being capped; `handlers` go on whatever the POINTER should count as
 // hovering, which is deliberately not the same node — a bubble's attachments render outside it.
-function useStickyCollapse(sticky: boolean | undefined, padY: string) {
+// `boundedRef` is the element the 85vh ceiling is meant to bound, when that is NOT the capped box
+// itself: AnswersCard caps its answer ROWS and wears its card chrome (head, `p-4`, border) outside
+// them, so capping the rows at 85vh would put the card at 85vh + chrome. Omit it when the capped box
+// IS the whole thing (the bubble).
+function useStickyCollapse(sticky: boolean | undefined, padY: string, boundedRef?: { readonly current: HTMLElement | null }) {
   const ref = useRef<HTMLDivElement>(null)
   const [expanded, setExpanded] = useState(false)
   const [overflows, setOverflows] = useState(false)
@@ -2934,18 +2938,42 @@ function useStickyCollapse(sticky: boolean | undefined, padY: string) {
   // Measure the real content height so max-height animates BOTH ways smoothly (a bare collapsed↔85vh
   // transition visibly lags on collapse) and so the fade shows ONLY when the text actually overflows.
   const [maxH, setMaxH] = useState<string | null>(null)
+  // The cap this hook last applied, and whether a max-height tween is still running toward it — which
+  // is how `measure` knows whether the box it is reading has settled. See the overflow test below.
+  const appliedMax = useRef<string | null>(null)
+  const capAnimating = useRef(false)
   const measure = useCallback(() => {
     const el = ref.current
-    if (!sticky || !el) { setMaxH(null); setOverflows(false); setExceedsCap(false); return }
-    const cap = Math.round((typeof window === "undefined" ? 800 : window.innerHeight) * 0.85)
+    if (!sticky || !el) { setMaxH(null); setOverflows(false); setExceedsCap(false); appliedMax.current = null; return }
+    const chrome = boundedRef?.current
+      ? Math.max(0, boundedRef.current.getBoundingClientRect().height - el.getBoundingClientRect().height)
+      : 0
+    const cap = Math.max(0, Math.round((typeof window === "undefined" ? 800 : window.innerHeight) * 0.85 - chrome))
     setExceedsCap(el.scrollHeight > cap)
+    const next = expanded ? `${Math.min(el.scrollHeight, cap)}px` : collapsedAskMax(padY)
     // THE OVERFLOW TEST IS READ OFF THE BOX, not computed from a line height. `clientHeight` while
     // collapsed IS whatever `calc(4lh + …)` resolved to in this font at this size, so the fade appears
     // exactly when there is something under it — with no second copy of the cap's arithmetic here to
     // drift from the CSS. It is only meaningful while collapsed; expanded, the box is the content.
-    if (!expanded) setOverflows(el.scrollHeight > el.clientHeight + 1)
-    setMaxH(expanded ? `${Math.min(el.scrollHeight, cap)}px` : collapsedAskMax(padY))
-  }, [sticky, expanded, padY])
+    //
+    // But it can only TURN THE FADE OFF from a settled box. While max-height is animating, the box is
+    // whatever size the tween is passing through — on the mouse-leave render it is still the EXPANDED
+    // height, where nothing overflows — so clearing on that reading blanks the fade for the whole 200ms
+    // collapse and the card shows the bare hard cut this fade exists to hide (measured on the answers
+    // card: no fade from 358px all the way down to 78px, content 358px throughout). So while a tween is
+    // in flight the fade only ever turns ON, and transitionend below — the one moment the box is the
+    // size the state claims — is what clears the flag and lets a settled reading turn it off again.
+    // (Deriving "in flight" from the cap changing on THIS render is not enough: applying the new cap
+    // re-runs this effect a second time with the cap already equal to itself, and that pass reads a box
+    // one frame into the tween.)
+    if (appliedMax.current !== null && next !== appliedMax.current) capAnimating.current = true
+    if (!expanded) {
+      const over = el.scrollHeight > el.clientHeight + 1
+      setOverflows((prev) => (capAnimating.current ? prev || over : over))
+    }
+    setMaxH(next)
+    appliedMax.current = next
+  }, [sticky, expanded, padY, boundedRef])
   useLayoutEffect(() => { measure() })
   // Re-measure on viewport resize so the 85vh cap / exceedsCap gate never go stale under a window resize.
   useEffect(() => {
@@ -2982,6 +3010,7 @@ function useStickyCollapse(sticky: boolean | undefined, padY: string) {
     onCapTransitionEnd: sticky
       ? (e: { propertyName: string }) => {
           if (e.propertyName !== "max-height") return
+          capAnimating.current = false
           if (expanded && exceedsCap) setScrollReady(true)
           measure()
         }
@@ -3472,17 +3501,21 @@ function AnswersCard({ answers, queued, sticky, sourceId }: { answers: PairedAns
   // body type `4lh` is 78px of content box, and this card's head (`text-[16px] leading-6` = 24px) plus
   // CardContent's `mt-1` take 28px of it, leaving ~2.5 lines. A collapsed pinned card then reads as a
   // header and half an answer, not as the human's own words, while the bubble beside it shows four.
-  const { ref, collapsed, overflows, maxH, scrollable, reserveGutter, handlers, onCapTransitionEnd } = useStickyCollapse(sticky, "0px")
+  //
+  // The EXPANDED ceiling still bounds the whole card, though: 85vh applied to the rows alone would seat
+  // a hovered over-cap card at 85vh plus that same chrome, so the hook is handed the card to subtract it.
+  const cardRef = useRef<HTMLDivElement>(null)
+  const { ref, overflows, maxH, scrollable, reserveGutter, handlers, onCapTransitionEnd } = useStickyCollapse(sticky, "0px", cardRef)
   return (
     <div data-frizz-msg={sourceId} data-answers-card {...handlers} className={`self-end flex w-full max-w-[85%] flex-col items-end ${queued ? "opacity-50" : ""}`}>
-      <div className={`relative w-full min-w-0 ${BLOCK_RADIUS} rounded-br-sm border border-border-strong bg-elevated p-4`}>
+      <div ref={cardRef} className={`relative w-full min-w-0 ${BLOCK_RADIUS} rounded-br-sm border border-border-strong bg-elevated p-4`}>
         <CardHead icon={ListChecks} label="Answers" />
         <CardContent>
           <div
             ref={ref}
             onTransitionEnd={onCapTransitionEnd}
             style={{ ...(maxH ? { maxHeight: maxH } : {}), ...(reserveGutter ? { paddingRight: "var(--sbw)" } : {}) }}
-            className={`flex flex-col gap-2.5 ${sticky ? `transition-[max-height] duration-200 ease-out ${scrollable ? "overflow-y-auto" : "overflow-hidden"}` : ""}`}
+            className={`relative flex flex-col gap-2.5 ${sticky ? `transition-[max-height] duration-200 ease-out ${scrollable ? "overflow-y-auto" : "overflow-hidden"}` : ""}`}
           >
             {answers.map((a, i) => (
               <div key={i} className="flex flex-col gap-1">
@@ -3505,13 +3538,16 @@ function AnswersCard({ answers, queued, sticky, sourceId }: { answers: PairedAns
                 </div>
               </div>
             ))}
+            {/* Same soft "there's more" cue the bubble wears, in THIS card's fill rather than the
+                bubble's — a hard clip on a bordered card reads as a broken card, not as a collapsed one.
+                It lives INSIDE the capped box, as the bubble's does, so `bottom-0` IS the clip line by
+                construction. Hung on the card root instead it sat 16px lower (the card's `p-4`), leaving
+                the cut row of text under only 0.6 of the veil and visibly showing through. */}
+            {overflows && (
+              <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-elevated to-transparent" />
+            )}
           </div>
         </CardContent>
-        {/* Same soft "there's more" cue the bubble wears, in THIS card's fill rather than the bubble's —
-            a hard clip on a bordered card reads as a broken card, not as a collapsed one. */}
-        {overflows && (
-          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-elevated to-transparent" />
-        )}
       </div>
     </div>
   )

--- a/packages/web/src/components/ChatView.tsx
+++ b/packages/web/src/components/ChatView.tsx
@@ -3034,8 +3034,11 @@ function useStickyCollapse(sticky: boolean | undefined, padY: string, boundedRef
 // what the pictures may take, never a licence to take it, and a wide window hands out far more than the
 // 420px a picture draws in any other bubble. Unclamped, one 400x1200 screenshot on a pinned ask rendered
 // at 679px in a 900px-tall window and 1104px in a 1400px one, and two at 542px each — bigger pinned than
-// unpinned, which is exactly backwards. Clamped, one and two are left where they already were and only
-// a stack is touched: measured at a 1000px viewport, three go from 420px each to 241px and six to 110px.
+// unpinned, which is exactly backwards. Clamped, a lone picture keeps its usual 420px at every height
+// measured, and every other reading is scoped to the window it was taken in: at a 1000px viewport two
+// land at 372px each, three at 241px and six at 110px; at 900px two land at 329px each. Two stops being
+// clamped only above ~1113px of viewport height, where its share first reaches the 420px it would have
+// drawn anyway.
 // A scroll region was the other option and is worse twice over — it hides the very thing hovering is
 // FOR, and it takes the wheel from the transcript for as long as the pointer rests on the band.
 //

--- a/packages/web/src/components/ChatView.tsx
+++ b/packages/web/src/components/ChatView.tsx
@@ -37,7 +37,7 @@ import { useDeliverQueuedNow, useDeliverQueuedNowSupported } from "../lib/delive
 import { useInnerHtml } from "../lib/innerHtml.ts"
 import { useLocalFileCodeLinks } from "../lib/localFileCode.ts"
 import { shouldSubmitStagedEnter } from "../lib/composerKeyboard.ts"
-import { lastAskIndex, messagePresentationText } from "../lib/messagePresentation.ts"
+import { lastAskIndex, lastRetryIndex, messagePresentationText } from "../lib/messagePresentation.ts"
 import { snoozePresetInstant, formatSnoozeWake } from "../lib/snooze.ts"
 import { noteGithubRefs } from "../lib/githubHovercards.ts"
 import { AWAITING_FALLBACK_TITLE, AWAITING_PARK_BUTTON, awaitingForLabel, awaitingItemLabels, awaitingParkAction, awaitingPresentationLine, prWatchRefs } from "../lib/awaitingPresentation.ts"
@@ -264,6 +264,9 @@ function ChatView({ slug, virtualized }: { slug: string; virtualized: boolean })
   // why) — pinned to the top of the pane via StickyUserBand so it stays visible while the agent's reply
   // scrolls under it. -1 when the transcript has no human turn yet.
   const lastUserIdx = useMemo(() => lastAskIndex(messages), [messages])
+  // NOT the same index as the pin. Retry re-SENDS its text, so it wants the turn that actually
+  // faulted — a wake included — while the band wants the human's own words. See lastRetryIndex.
+  const lastRetryIdx = useMemo(() => lastRetryIndex(messages), [messages])
   // Client view pref: how (or whether) to pin the current ask to the pane top. `off` → no pin.
   const { stickyUserMessage } = useSnapshot(prefs)
   // Question-block interactivity in the thread view: EVERY ask stays answerable, wherever it sits —
@@ -504,7 +507,7 @@ function ChatView({ slug, virtualized }: { slug: string; virtualized: boolean })
                 slug={slug}
                 sessionId={thread.sessionId}
                 fault={thread.providerFault}
-                retryText={lastUserIdx >= 0 ? messages[lastUserIdx]?.text : undefined}
+                retryText={lastRetryIdx >= 0 ? messages[lastRetryIdx]?.text : undefined}
               />
             ) : thread?.limitPause && !thread.foreign ? (
               <LimitPauseCard slug={slug} sessionId={thread.sessionId} pause={thread.limitPause} />
@@ -693,6 +696,9 @@ function VirtualizedThreadTranscript({
     }))
   }, [activityMessages, lastAgentIdx])
   const lastUserIdx = useMemo(() => lastAskIndex(messages), [messages])
+  // NOT the same index as the pin. Retry re-SENDS its text, so it wants the turn that actually
+  // faulted — a wake included — while the band wants the human's own words. See lastRetryIndex.
+  const lastRetryIdx = useMemo(() => lastRetryIndex(messages), [messages])
   const hasRuntimeStatus = Boolean(
     (thread?.providerFault && !thread.foreign)
       || (thread?.limitPause && !thread.foreign)
@@ -1256,7 +1262,7 @@ function VirtualizedThreadTranscript({
             ) : row.kind === "runtime-status" ? (
               <div className="px-6" style={{ paddingTop: runtimeStatusGap }}>
                 {thread?.providerFault && !thread.foreign ? (
-                  <ProviderFaultCard slug={slug} sessionId={thread.sessionId} fault={thread.providerFault} retryText={lastUserIdx >= 0 ? messages[lastUserIdx]?.text : undefined} />
+                  <ProviderFaultCard slug={slug} sessionId={thread.sessionId} fault={thread.providerFault} retryText={lastRetryIdx >= 0 ? messages[lastRetryIdx]?.text : undefined} />
                 ) : thread?.limitPause && !thread.foreign ? (
                   <LimitPauseCard slug={slug} sessionId={thread.sessionId} pause={thread.limitPause} />
                 ) : (thread?.pendingInteraction ? undefined : thread?.pendingAsk) ? (
@@ -2896,9 +2902,10 @@ export function StickyUserBand({ children, stickyTopPx, sourceId }: { children: 
 // what you actually get is three crisp lines and a fourth dissolving, which is the ask restated rather
 // than reproduced.
 //
-// The caller supplies its OWN vertical padding, because `max-height` is a border-box measurement and
-// the two things that can hold the pin do not agree on it — the bubble is `py-3`, the answers card is
-// `p-4`. Baking the bubble's in would silently give the card three lines and a bit.
+// The caller supplies the vertical padding of the box it is capping, because `max-height` is a
+// border-box measurement: the bubble caps ITSELF and pays its `py-3`, while the answers card caps the
+// answer rows inside its chrome and so pays nothing. Baking the bubble's figure in would have given
+// the card a budget it then spent on its own header.
 //
 // It replaced a flat 200px, which was ~8 lines of a 14px font — half a drawer, and that was BEFORE the
 // attachments below it, which the cap never covered at all (see the image row).
@@ -2964,8 +2971,20 @@ function useStickyCollapse(sticky: boolean | undefined, padY: string) {
           onMouseLeave: () => { setExpanded(false); setScrollReady(false) },
         }
       : {},
+    // RE-MEASURE WHEN THE ANIMATION LANDS, which is the only moment the box is the size the state
+    // says it is. `measure()` on the leave RENDER reads a box still mid-transition — max-height
+    // animates length→length, so `clientHeight` is still the EXPANDED height in that task. For a
+    // message shorter than the 85vh cap, expanded clientHeight IS scrollHeight, so the overflow test
+    // read false, `Message` is memoized so nothing re-measured, and the pinned ask stayed hard-clipped
+    // mid-word with no fade for the rest of the session — the "hard cut reads as broken" this fade
+    // exists to prevent. Measured on the queue card at 1800x1000 with a 528px ask: fade present, hover,
+    // leave, fade gone forever. The scrollReady flip stays the expanded-and-over-cap special case.
     onCapTransitionEnd: sticky
-      ? (e: { propertyName: string }) => { if (e.propertyName === "max-height" && expanded && exceedsCap) setScrollReady(true) }
+      ? (e: { propertyName: string }) => {
+          if (e.propertyName !== "max-height") return
+          if (expanded && exceedsCap) setScrollReady(true)
+          measure()
+        }
       : undefined,
   }
 }
@@ -3447,18 +3466,24 @@ function AnswersCard({ answers, queued, sticky, sourceId }: { answers: PairedAns
   // so unlike a scheduler wake it BELONGS in the band — but it ignored `sticky` entirely and had no
   // ceiling, so answering four questions with pasted paragraphs floated an unbounded card over the
   // transcript. Same collapse as the bubble beside it: four lines, a fade, hover for the rest.
-  const { ref, collapsed, overflows, maxH, scrollable, reserveGutter, handlers, onCapTransitionEnd } = useStickyCollapse(sticky, "2rem") // p-4
+  //
+  // THE CAP SITS ON THE ANSWERS, NOT ON THE CARD, so `padY` is zero: the capped box is the answer rows
+  // and nothing else. Capping the card root instead spends the four-line budget on chrome — at the 13px
+  // body type `4lh` is 78px of content box, and this card's head (`text-[16px] leading-6` = 24px) plus
+  // CardContent's `mt-1` take 28px of it, leaving ~2.5 lines. A collapsed pinned card then reads as a
+  // header and half an answer, not as the human's own words, while the bubble beside it shows four.
+  const { ref, collapsed, overflows, maxH, scrollable, reserveGutter, handlers, onCapTransitionEnd } = useStickyCollapse(sticky, "0px")
   return (
     <div data-frizz-msg={sourceId} data-answers-card {...handlers} className={`self-end flex w-full max-w-[85%] flex-col items-end ${queued ? "opacity-50" : ""}`}>
-      <div
-        ref={ref}
-        onTransitionEnd={onCapTransitionEnd}
-        style={{ ...(maxH ? { maxHeight: maxH } : {}), ...(reserveGutter ? { paddingRight: "calc(1rem + var(--sbw))" } : {}) }}
-        className={`relative w-full min-w-0 ${BLOCK_RADIUS} rounded-br-sm border border-border-strong bg-elevated p-4 ${sticky ? `transition-[max-height] duration-200 ease-out ${scrollable ? "overflow-y-auto" : "overflow-hidden"}` : ""}`}
-      >
+      <div className={`relative w-full min-w-0 ${BLOCK_RADIUS} rounded-br-sm border border-border-strong bg-elevated p-4`}>
         <CardHead icon={ListChecks} label="Answers" />
         <CardContent>
-          <div className="flex flex-col gap-2.5">
+          <div
+            ref={ref}
+            onTransitionEnd={onCapTransitionEnd}
+            style={{ ...(maxH ? { maxHeight: maxH } : {}), ...(reserveGutter ? { paddingRight: "var(--sbw)" } : {}) }}
+            className={`flex flex-col gap-2.5 ${sticky ? `transition-[max-height] duration-200 ease-out ${scrollable ? "overflow-y-auto" : "overflow-hidden"}` : ""}`}
+          >
             {answers.map((a, i) => (
               <div key={i} className="flex flex-col gap-1">
                 {a.question && (

--- a/packages/web/src/components/ImageFrame.tsx
+++ b/packages/web/src/components/ImageFrame.tsx
@@ -41,3 +41,8 @@ export const IMAGE_FRAME_MAT = "flex justify-center bg-panel-2 p-1.5"
 // The picture inside the frame: never wider than the mat, never taller than a screenful, always keeping
 // its intrinsic aspect. Shared so the frame's contents are as consistent as the frame itself.
 export const FRAMED_IMAGE = "block max-h-[420px] max-w-full w-auto rounded-md object-contain"
+
+// The same "screenful" as a NUMBER, for the one caller that has to compare against it rather than
+// apply it. Tailwind needs the literal inside the class string, so the two cannot be derived from
+// each other — keep them equal.
+export const FRAMED_IMAGE_MAX_PX = 420

--- a/packages/web/src/components/TodosView.tsx
+++ b/packages/web/src/components/TodosView.tsx
@@ -11,6 +11,7 @@ import { orderQueue, queued, displayTitle, lastActiveLabelAt } from "../groups.t
 import { useLiveAnswering } from "../lib/answering.ts"
 import { shouldSubmitStagedEnter } from "../lib/composerKeyboard.ts"
 import { hasQuestionBlock } from "../lib/questionBlocks.ts"
+import { lastAskIndex } from "../lib/messagePresentation.ts"
 import { collapseMiddleRuns, opensQueueSegment, queueCollapseSegments, segmentFolds, supersededAskIndices, survivesQueueCollapse } from "../lib/queueCollapse.ts"
 import { pairAllAnswers } from "../lib/answersMessage.ts"
 import { Message, PermPolicyDenialCard, PermPromptBanner, PendingAskCard, StickyUserBand, VSpace, STEP, messageTailIsMeta, messageHeadIsMeta, messageRendersNothing, messageHasRenderableText, lastAssistantIndex } from "./ChatView.tsx"
@@ -832,10 +833,23 @@ const QueueCard = memo(function QueueCard({ thread, leaving, onResolve, onUnreso
     }
     return 0
   }, [messages])
-  // Which message gets pinned to the pane top (StickyUserBand). The most recent LANDED user message —
-  // queued/optimistic follow-ups pin to the card bottom and aren't the "current ask", and are skipped
-  // by the first render pass anyway, so anchoring the band on one would drop it entirely. -1 → none.
-  const stickyUserIdx = useMemo(() => {
+  // Which message gets pinned to the pane top (StickyUserBand) — the HUMAN'S CURRENT ASK, on exactly
+  // the predicate the thread view pins on. -1 → nothing pinned.
+  //
+  // This used to be its own `role === "user" && !queued` walk, which is not the same thing: frizz writes
+  // as the user too, and `lastAskIndex` already knows it. A fired one-off timer is a `user` record, so it
+  // won the pin — and unlike a bubble (which collapses to four lines with hover-to-expand) a wake ignores
+  // `sticky` entirely, so an unparsed one took FrizzWake's uncapped fallback card and the WHOLE delivered
+  // prompt floated over the queue card and hid it (maintainer 2026-08-21: "this dialog covers the entire
+  // chat contents"). `lastAskIndex` is the shared answer, and it also drops a sub-agent's upward report,
+  // which this walk never excluded either.
+  const stickyUserIdx = useMemo(() => lastAskIndex(messages), [messages])
+  // The COLLAPSE's own anchor test, deliberately NOT the pin. It asks something weaker — "is there any
+  // landed user row above the first fold for the collapse to hang under" — and a wake row is one, in
+  // flow, whether or not it is pinned. Keeping the old walk here is what makes the pin fix change the
+  // pin and nothing else; folding the two together would silently switch collapsing off on a
+  // wake-driven card that has no rest divider above it.
+  const anchorRowIdx = useMemo(() => {
     for (let i = messages.length - 1; i >= 0; i--) if (messages[i].role === "user" && !messages[i].queued) return i
     return -1
   }, [messages])
@@ -929,7 +943,7 @@ const QueueCard = memo(function QueueCard({ thread, leaving, onResolve, onUnreso
   // Collapse unless the reader has opted into the full log. Gated on there being something ABOVE the
   // first fold to anchor it — a pinned ask, or a rest divider a wake-driven turn opens on.
   const collapseIntermediate =
-    !intermediateExpanded && (stickyUserIdx >= 0 || restTurnStart > 0) && segments.length > 0
+    !intermediateExpanded && (anchorRowIdx >= 0 || restTurnStart > 0) && segments.length > 0
   // THE HUMAN'S LAST MESSAGE WINS, even when the agent has rested since. It used to be capped at the
   // current turn (`Math.max` with `restTurnStart`) on the reasoning that a closed turn is history the
   // drawer already holds — but with frizz driving threads across many rests, "the current turn" is a

--- a/packages/web/src/components/TodosView.tsx
+++ b/packages/web/src/components/TodosView.tsx
@@ -805,11 +805,16 @@ const QueueCard = memo(function QueueCard({ thread, leaving, onResolve, onUnreso
   // 2026-08-12: "queue cards STILL need to go all the way back to the last user message. that's
   // important context that needs to be surfaced").
   //
-  // A queued send is skipped too: it has not been delivered, so nothing after it is a reply to it.
+  // A queued send is skipped too: it has not been delivered, so nothing after it is a reply to it. And
+  // a SUB-AGENT'S REPORT for the same reason `wake` is skipped — `peerFrom` is the server's tell that a
+  // CHILD wrote the turn, so anchoring there cuts the card at a child's status line and hides the human's
+  // task exactly as a wake did. (Still not `lastAskIndex`: that answers "what is the human waiting on"
+  // and returns -1 when there is nothing, where this one asks "how far back must the window reach" and
+  // falls back to the start of the transcript.)
   const lastUserIdx = useMemo(() => {
     for (let i = messages.length - 1; i >= 0; i--) {
       const m = messages[i]
-      if (m.role === "user" && !m.wake && !m.queued) return i
+      if (m.role === "user" && !m.wake && !m.queued && !m.peerFrom) return i
     }
     return 0
   }, [messages])

--- a/packages/web/src/lib/messagePresentation.test.ts
+++ b/packages/web/src/lib/messagePresentation.test.ts
@@ -13,11 +13,12 @@ test("messagePresentationText leaves ordinary messages and HTML comments untouch
   assert.equal(messagePresentationText({ text }), text)
 })
 
-test("lastAskIndex pins the human's latest landed turn, never a queued one or a sub-agent's report", () => {
+test("lastAskIndex pins the human's latest landed turn, never a queued one, a sub-agent's report or a wake", () => {
   const ask = { role: "user" as const }
   const reply = { role: "assistant" as const }
   const report = { role: "user" as const, peerFrom: "bun_project_survey" }
   const queued = { role: "user" as const, queued: true }
+  const wake = { role: "user" as const, wake: true }
 
   assert.equal(lastAskIndex([ask, reply]), 0)
   // An orchestrator's children report continuously; each is a `user` row the human never wrote, and
@@ -25,8 +26,13 @@ test("lastAskIndex pins the human's latest landed turn, never a queued one or a 
   assert.equal(lastAskIndex([ask, reply, report, report]), 0)
   // A queued follow-up pins to the bottom until it lands, so it is not the ask either.
   assert.equal(lastAskIndex([ask, report, queued]), 0)
+  // A SCHEDULER WAKE is frizz's own turn, not the human's — and unlike every bubble it renders as an
+  // uncapped card, so pinning one floats the whole delivered prompt over the transcript.
+  assert.equal(lastAskIndex([ask, reply, wake]), 0)
+  assert.equal(lastAskIndex([ask, wake, report, wake]), 0)
   // A genuine later human turn does take the pin back.
   assert.equal(lastAskIndex([ask, report, { role: "user" as const }]), 2)
   assert.equal(lastAskIndex([reply, report]), -1)
+  assert.equal(lastAskIndex([reply, wake]), -1)
   assert.equal(lastAskIndex([]), -1)
 })

--- a/packages/web/src/lib/messagePresentation.test.ts
+++ b/packages/web/src/lib/messagePresentation.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
-import { lastAskIndex, messagePresentationText } from "./messagePresentation.ts"
+import { lastAskIndex, lastRetryIndex, messagePresentationText } from "./messagePresentation.ts"
 
 test("messagePresentationText prefers a validated display projection without changing full text", () => {
   const message = { text: "compact\n\n<!-- boundary -->\n\nlarge machine tail", displayText: "compact" }
@@ -35,4 +35,23 @@ test("lastAskIndex pins the human's latest landed turn, never a queued one, a su
   assert.equal(lastAskIndex([reply, report]), -1)
   assert.equal(lastAskIndex([reply, wake]), -1)
   assert.equal(lastAskIndex([]), -1)
+})
+
+test("lastRetryIndex re-sends the turn that faulted, wake included, never a queued or peer turn", () => {
+  const ask = { role: "user" as const }
+  const reply = { role: "assistant" as const }
+  const report = { role: "user" as const, peerFrom: "bun_project_survey" }
+  const queued = { role: "user" as const, queued: true }
+  const wake = { role: "user" as const, wake: true }
+
+  // THE DIVERGENCE FROM lastAskIndex, and the whole reason this exists: a provider fault on a
+  // freshly delivered wake must retry THAT wake, not resend an older ask the worker already answered.
+  assert.equal(lastRetryIndex([ask, reply, wake]), 2)
+  assert.equal(lastAskIndex([ask, reply, wake]), 0)
+  // Everything else the two agree on.
+  assert.equal(lastRetryIndex([ask, reply]), 0)
+  assert.equal(lastRetryIndex([ask, wake, report]), 1)
+  assert.equal(lastRetryIndex([ask, wake, queued]), 1)
+  assert.equal(lastRetryIndex([reply, report]), -1)
+  assert.equal(lastRetryIndex([]), -1)
 })

--- a/packages/web/src/lib/messagePresentation.ts
+++ b/packages/web/src/lib/messagePresentation.ts
@@ -10,16 +10,28 @@ export function messagePresentationText(message: Pick<TranscriptMessage, "text" 
 // the pane top (ChatView's StickyUserBand) and supplies the retry text after a provider fault, so "who
 // wrote it" decides it — not the `user` role, which the transcript also uses for machine-written turns.
 //
-// Excluded: a QUEUED/optimistic follow-up (it pins to the bottom until it lands), and a SUB-AGENT's
-// upward report — `peerFrom` is the server's own tell that a CHILD wrote the turn, and a child
-// reporting in is neither an ask nor anything to retry. Without that second guard an orchestrator
-// running a dozen children re-pins the band to "Sub-agent «…» reported" on every report, burying the
-// human's actual instruction, and a fault retry would resend the child's words as the human's.
+// Excluded: a QUEUED/optimistic follow-up (it pins to the bottom until it lands), a SUB-AGENT's
+// upward report, and a SCHEDULER WAKE. `peerFrom` and `wake` are the server's own tells that a CHILD
+// or FRIZZ ITSELF wrote the turn (the schema calls them one defect class), and neither is an ask or
+// anything to retry. Without the `peerFrom` guard an orchestrator running a dozen children re-pins the
+// band to "Sub-agent «…» reported" on every report, burying the human's actual instruction, and a
+// fault retry would resend the child's words as the human's.
+//
+// `wake` is the same failure with a worse blast radius, because a wake does not render as a BUBBLE.
+// UserBubble collapses a pinned ask to four lines with hover-to-expand, so no human turn can ever
+// swallow the pane; the wake branches ahead of it (RecurringPromptLine, FrizzWake) ignore `sticky` and
+// have no cap at all. A wake whose prose no parser recognizes takes FrizzWake's fallback — a full
+// TranscriptCard holding the ENTIRE delivered text — so pinning one floated a ~1700px card over the
+// transcript and the thread became unreadable (maintainer 2026-08-21: "this dialog covers the entire
+// chat contents"). Capping that card would be the wrong repair, and it is not enough that most wakes
+// now draw a one-line divider instead: frizz's own scheduler turn is not the human's ask, so it has no
+// business in the current-ask band whatever its height, and a hairline pinned there stands exactly
+// where the instruction the human is waiting on should be. It still renders in flow, in order.
 // -1 when the transcript holds no human turn yet.
-export function lastAskIndex(messages: readonly Pick<TranscriptMessage, "role" | "queued" | "peerFrom">[]): number {
+export function lastAskIndex(messages: readonly Pick<TranscriptMessage, "role" | "queued" | "peerFrom" | "wake">[]): number {
   for (let i = messages.length - 1; i >= 0; i--) {
     const m = messages[i]
-    if (m.role === "user" && !m.queued && !m.peerFrom) return i
+    if (m.role === "user" && !m.queued && !m.peerFrom && !m.wake) return i
   }
   return -1
 }

--- a/packages/web/src/lib/messagePresentation.ts
+++ b/packages/web/src/lib/messagePresentation.ts
@@ -35,3 +35,24 @@ export function lastAskIndex(messages: readonly Pick<TranscriptMessage, "role" |
   }
   return -1
 }
+
+// THE TURN A PROVIDER FAULT INTERRUPTED — what ProviderFaultCard's Retry re-SENDS after a sign-in, and
+// deliberately not the same question as the pin above.
+//
+// The two diverge on `wake` alone. The band asks "whose words are these", because it is a REMINDER of
+// what the human is waiting on and frizz's own scheduled turn is not that. Retry asks "what failed",
+// and a wake that the provider rejected is exactly what failed: substituting the previous human ask
+// would resend words already answered and silently drop the scheduled work the fault interrupted. A
+// signed-out provider rejecting a freshly delivered wake is a real path, and the auth-error record is
+// never written as an assistant row, so the wake genuinely is the last visible turn when it happens.
+//
+// `peerFrom` and `queued` are excluded for BOTH consumers and for the same reasons they always were: a
+// child's report must never be resent as the human's words, and a queued follow-up has not been sent
+// yet, so there is nothing to re-send.
+export function lastRetryIndex(messages: readonly Pick<TranscriptMessage, "role" | "queued" | "peerFrom">[]): number {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i]
+    if (m.role === "user" && !m.queued && !m.peerFrom) return i
+  }
+  return -1
+}

--- a/packages/web/src/lib/messagePresentation.ts
+++ b/packages/web/src/lib/messagePresentation.ts
@@ -7,15 +7,15 @@ export function messagePresentationText(message: Pick<TranscriptMessage, "text" 
 }
 
 // The CURRENT ASK: the most recent user turn the HUMAN is actually waiting on an answer to. It pins to
-// the pane top (ChatView's StickyUserBand) and supplies the retry text after a provider fault, so "who
-// wrote it" decides it — not the `user` role, which the transcript also uses for machine-written turns.
+// the pane top (ChatView's StickyUserBand), so "who wrote it" decides it — not the `user` role, which
+// the transcript also uses for machine-written turns. What a provider fault re-sends is a DIFFERENT
+// walk over the same rows; it diverges on `wake` alone, and lives in lastRetryIndex below.
 //
 // Excluded: a QUEUED/optimistic follow-up (it pins to the bottom until it lands), a SUB-AGENT's
 // upward report, and a SCHEDULER WAKE. `peerFrom` and `wake` are the server's own tells that a CHILD
-// or FRIZZ ITSELF wrote the turn (the schema calls them one defect class), and neither is an ask or
-// anything to retry. Without the `peerFrom` guard an orchestrator running a dozen children re-pins the
-// band to "Sub-agent «…» reported" on every report, burying the human's actual instruction, and a
-// fault retry would resend the child's words as the human's.
+// or FRIZZ ITSELF wrote the turn (the schema calls them one defect class), and neither is the human's
+// ask. Without the `peerFrom` guard an orchestrator running a dozen children re-pins the band to
+// "Sub-agent «…» reported" on every report, burying the human's actual instruction.
 //
 // `wake` is the same failure with a worse blast radius, because a wake does not render as a BUBBLE.
 // UserBubble collapses a pinned ask to four lines with hover-to-expand, so no human turn can ever

--- a/packages/web/src/sticky-user-message-fixture.tsx
+++ b/packages/web/src/sticky-user-message-fixture.tsx
@@ -24,6 +24,10 @@ import "./styles.css"
 //                           lastAskIndex.
 //   ?sticky=on|off  the client stickyUserMessage view pref. Pinned ON by default HERE (the app's own
 //                   default is off) — this fixture exists to QA the pinned band, so it must show one.
+//   ?font=mono      this app renders in TWO type families (html[data-font], applied before first paint)
+//                   and the collapsed cap is `4lh` — one line box of the RESOLVED font — so the band is
+//                   a different height in each. Defaults to `sans`, index.html's own default; a fixture
+//                   that leaves data-font unset silently renders mono and measures the wrong band.
 //   ?img=<abs path> attach that picture to the pinned ask (repeatable, comma-separated). The
 //                   attachments render OUTSIDE the bubble, so they are capped separately from the
 //                   prose — collapsed they are a row of thumbnails, hovered they return to full size.
@@ -34,6 +38,7 @@ const surface = surfaceParam === "drawer" ? "drawer" : surfaceParam === "fence" 
 const sizeParam = params.get("size")
 const size = sizeParam === "tall" ? "tall" : sizeParam === "medium" ? "medium" : sizeParam === "wake" ? "wake" : sizeParam === "answers" ? "answers" : "short"
 prefs.stickyUserMessage = params.get("sticky") !== "off"
+document.documentElement.dataset.font = params.get("font") === "mono" ? "mono" : "sans"
 
 const SLUG = "sticky-demo"
 

--- a/packages/web/src/sticky-user-message-fixture.tsx
+++ b/packages/web/src/sticky-user-message-fixture.tsx
@@ -13,14 +13,26 @@ import "./styles.css"
 // of the scroll pane in BOTH the drawer (ChatView) and the queue card (TodosView), with top padding
 // and a max-height that gives a very tall ask its own internal scroll.
 //   ?surface=queue|drawer   which surface to render (default queue)
-//   ?size=short|tall        short one-line ask, or a very tall ask (exercise max-h + inner scroll)
+//   ?size=short|tall|wake   short one-line ask; a very tall ask (exercise max-h + inner scroll); or a
+//                           tall SCHEDULER WAKE landing after the human's ask — frizz's own turn, which
+//                           is NOT the current ask and so must never take the pin (lastAskIndex).
+//                           `?size=answers` pins the OTHER thing that can be the current ask — the
+//                           human's composed multi-block answer, which renders as AnswersCard rather
+//                           than a bubble and collapses on the same four-line rule.
+//                           QA `?size=wake` on BOTH surfaces: each pins from its own call site, and
+//                           they carried this defect independently until both were pointed at
+//                           lastAskIndex.
 //   ?sticky=on|off  the client stickyUserMessage view pref. Pinned ON by default HERE (the app's own
 //                   default is off) — this fixture exists to QA the pinned band, so it must show one.
+//   ?img=<abs path> attach that picture to the pinned ask (repeatable, comma-separated). The
+//                   attachments render OUTSIDE the bubble, so they are capped separately from the
+//                   prose — collapsed they are a row of thumbnails, hovered they return to full size.
+//                   Load through the adhoc stack, whose /local-image serves os.tmpdir().
 const params = new URLSearchParams(location.search)
 const surfaceParam = params.get("surface")
 const surface = surfaceParam === "drawer" ? "drawer" : surfaceParam === "fence" ? "fence" : surfaceParam === "sentfiles" ? "sentfiles" : "queue"
 const sizeParam = params.get("size")
-const size = sizeParam === "tall" ? "tall" : sizeParam === "medium" ? "medium" : "short"
+const size = sizeParam === "tall" ? "tall" : sizeParam === "medium" ? "medium" : sizeParam === "wake" ? "wake" : sizeParam === "answers" ? "answers" : "short"
 prefs.stickyUserMessage = params.get("sticky") !== "off"
 
 const SLUG = "sticky-demo"
@@ -35,17 +47,54 @@ const mediumAsk = Array.from({ length: 8 }, (_, i) =>
 const tallAsk = Array.from({ length: 30 }, (_, i) =>
   `Line ${i + 1}: this is a deliberately very tall user message so the pinned band exceeds the pane height and must scroll within its own max-height instead of swallowing the whole viewport.`,
 ).join("\n")
-const askFor = (s: typeof size) => (s === "tall" ? tallAsk : s === "medium" ? mediumAsk : shortAsk)
+// The wire form useLiveAnswering.sendAnswers writes for a multi-block answer, which parseAnswersCard
+// turns back into the structured card. Long free-text answers are the case that made it uncappable.
+const answersAsk = [
+  "Answers:",
+  ...Array.from({ length: 5 }, (_, i) =>
+    `${i + 1}. Option ${String.fromCharCode(65 + i)} — and a long free-text rider on top of the choice, because an answer block accepts continuation lines and pasted paragraphs, which is exactly how this card grew past the pane.`),
+].join("\n")
+const askFor = (s: typeof size) => (s === "tall" ? tallAsk : s === "medium" ? mediumAsk : s === "answers" ? answersAsk : shortAsk)
+
+// A WAKE FRIZZ DELIVERED, in the shape that broke this band: a worker's own scheduled prompt, pasted
+// back in. It is recorded as a `user` turn because frizz pastes it into the worker's composer, so
+// `wake` is the server's tell that frizz — not the human — wrote it.
+//
+// No parser in FrizzWake recognizes this text, so it takes the unstructured fallback: a full
+// TranscriptCard holding the WHOLE delivered prompt, with no height cap and no `sticky` handling.
+// Pinned, that card floated over the entire transcript. The wakes that DO parse (a fired timer with its
+// trailer, a PR poll, a shell finishing) draw a one-line divider instead — a quieter symptom of the
+// identical defect, since a hairline pinned in the ask band is still standing where the human's
+// instruction should be. Both are excluded by the same guard.
+const unparsedWake = [
+  "PRD-8179 ceiling follow-up / PR #3787 check-in. Worktree `.claude/worktrees/prd-8179-ax-mode-instrumentation`, branch `fix/prd-8179-pin-annotation-ceiling`, HEAD 9d2de14e74 (3 commits, TESTS + COMMENTS ONLY).",
+  "REVIEW LOOP IS CLOSED. The 23:15Z review was APPROVE WITH SUGGESTIONS (Risk: Low), its single Minor is fixed in the final commit, and its two other items were self-discarded as pre-existing and out of scope. DO NOT start another polish round.",
+  "1. `gh pr view 3787 --json state,mergedAt,mergeStateStatus` + queue timeline.\n   - MERGED → check for any review newer than 2026-08-21T23:15:48Z. If nothing Major landed: drop the watcher and sign off.\n   - still queued / CI pending → set a NEW ~45min timer and name the PR AND the new timer id. A fired one-shot is spent.\n   - `removed_from_merge_queue` → DO NOT REBASE; the queue is ALLGREEN/max-5, so another PR's failure dequeues the whole group.",
+  "PUSH-LOCK: dequeue via `gh api graphql`, push, then re-arm `gh pr merge 3787 --squash --auto`.",
+  "Node 24: export PATH=\"/Users/you/.local/share/fnm/node-versions/v24.18.0/installation/bin:$PATH\". Never run lint and the full test suite concurrently.",
+].join("\n\n")
 
 const longReply = Array.from({ length: 40 }, (_, i) =>
   `**Paragraph ${i + 1}.** The assistant reply is intentionally long so the pane scrolls and the pinned ask stays visible above it. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
 ).join("\n\n")
 
+// The composer parks attachments as TRAILING standalone absolute-path lines and the bubble peels them
+// back off (splitComposerValue), so a fixture attachment is spelled exactly the way a real send is.
+const askImages = (params.get("img") ?? "").split(",").map((p) => p.trim()).filter(Boolean)
+const withAttachments = (prose: string) => [prose, ...askImages].join("\n")
+
 const messages: TranscriptMessage[] = [
   { sourceId: "u0", role: "user", text: "First, an older ask that should scroll away normally.", tools: [], parts: [] },
   { sourceId: "a0", role: "assistant", text: "Sure — here is an earlier reply.", tools: [], parts: [{ kind: "text", text: "Sure — here is an earlier reply." }] },
-  { sourceId: "u1", role: "user", text: askFor(size), tools: [], parts: [] },
+  // THE PINNED ASK. Under `?size=answers` its text is the answers wire form, so it renders as
+  // AnswersCard rather than a bubble — unpaired with any question, which is all this fixture needs.
+  { sourceId: "u1", role: "user", text: withAttachments(askFor(size === "wake" ? "short" : size)), tools: [], parts: [] },
   { sourceId: "a1", role: "assistant", text: longReply, tools: [], parts: [{ kind: "text", text: longReply }] },
+  // The wake lands LAST, after the reply — exactly where a delivered wake lands. The human's ask above it
+  // must keep the pin, and this card must stay in the flow at the bottom of the transcript.
+  ...(size === "wake"
+    ? [{ sourceId: "w1", role: "user", text: unparsedWake, wake: true, tools: [], parts: [] } as TranscriptMessage]
+    : []),
 ]
 
 const thread: ThreadViewModel = {

--- a/packages/web/src/stickyUserMessage.e2e.test.ts
+++ b/packages/web/src/stickyUserMessage.e2e.test.ts
@@ -245,12 +245,16 @@ test("a hovered pinned card never grows past the 85vh ceiling", {
   }
 })
 
-// BOTH prose heights, because they exercise different halves of the budget. `short` is one line, so the
-// prose is the same height collapsed and expanded; `medium` grows 108px -> 360px on the same hover the
-// pictures are being sized for, which is the case a budget struck against a mid-transition read gets
-// wrong (measured 1101px in a 1000px window before the wrapper was observed).
-for (const size of ["short", "medium"]) {
-test(`a pinned ask's pictures share the 85vh ceiling rather than clearing it (${size} prose)`, {
+// Three arms, because the budget has two halves and its clamp has a third. The prose heights exercise
+// the budget: `short` is one line, so it is the same height collapsed and expanded, while `medium` grows
+// 108px -> 360px on the same hover the pictures are being sized for, which is the case a budget struck
+// against a mid-transition read gets wrong (measured 1101px in a 1000px window before the wrapper was
+// observed). The picture COUNT exercises the clamp, and three is the count that hides its absence: three
+// tall screenshots want more than a 1000px window has, so the budget binds either way. ONE wants less,
+// so an unclamped budget hands it MORE than it would have taken — 1104px in a 1400px-tall window against
+// the 420px it draws in every other bubble.
+for (const [size, count] of [["short", 3], ["medium", 3], ["short", 1]] as const) {
+test(`a pinned ask's pictures share the 85vh ceiling rather than clearing it (${size} prose, ${count} ${count === 1 ? "picture" : "pictures"})`, {
   skip: !baseUrl,
   timeout: 60_000,
 }, async () => {
@@ -259,6 +263,13 @@ test(`a pinned ask's pictures share the 85vh ceiling rather than clearing it (${
   try {
     const page = await browser.newPage()
     await page.setViewport({ width: 1400, height: 1000, deviceScaleFactor: 1 })
+    // Watched because the hook under test is loop-shaped — a ResizeObserver callback writing a custom
+    // property onto a descendant of the observed element — and "ResizeObserver loop completed with
+    // undelivered notifications" is how Chrome reports one that fails to settle. It settles here in
+    // three rounds during the expand tween, and this is what would notice if it stopped.
+    const errors: string[] = []
+    page.on("console", (m) => { if (m.type() === "error" && !/404|favicon/i.test(m.text())) errors.push(m.text()) })
+    page.on("pageerror", (e) => errors.push(String(e)))
     // The attachments are real `/local-image` requests for real absolute paths — the fixture spells a
     // send exactly the way the composer does — so the pictures are served here rather than the fixture
     // being taught to fake them. Deliberately TALLER than it is wide: unconstrained, each one renders
@@ -276,7 +287,7 @@ test(`a pinned ask's pictures share the 85vh ceiling rather than clearing it (${
       })
     })
 
-    const paths = ["/tmp/shot-a.png", "/tmp/shot-b.png", "/tmp/shot-c.png"].join(",")
+    const paths = ["/tmp/shot-a.png", "/tmp/shot-b.png", "/tmp/shot-c.png"].slice(0, count).join(",")
     await page.goto(`${baseUrl}/sticky-user-message-fixture.html?surface=queue&size=${size}&img=${paths}`, { waitUntil: "networkidle0" })
     await page.waitForSelector("[data-transcript-sticky] img")
 
@@ -291,10 +302,10 @@ test(`a pinned ask's pictures share the 85vh ceiling rather than clearing it (${
     })
 
     const shut = await measure()
-    // Collapsed is the half that already worked, and the picture ceiling must not disturb it: three
-    // screenshots still cost ONE band of thumbnails, not three.
-    assert.equal(shut.imgH.length, 3)
-    assert.ok(shut.msgH < 250, `collapsed, three pictures are one thumbnail row (was ${shut.msgH}px)`)
+    // Collapsed is the half that already worked, and the picture ceiling must not disturb it: N
+    // screenshots still cost ONE band of thumbnails, not N.
+    assert.equal(shut.imgH.length, count)
+    assert.ok(shut.msgH < 250, `collapsed, the pictures are one thumbnail row (was ${shut.msgH}px)`)
 
     await page.evaluate(() => {
       document.querySelector("[data-transcript-sticky] [data-frizz-msg]")!
@@ -308,8 +319,14 @@ test(`a pinned ask's pictures share the 85vh ceiling rather than clearing it (${
     // 101.7% of a 1000px window and 145.4% of a 700px one, the pinned element hiding the transcript it
     // is pinned above. They now split what the ceiling leaves them.
     assert.ok(open.imgH.every((h) => h > shut.imgH[0]!), "hovering still grows the pictures")
-    assert.ok(open.imgH.every((h) => h < 420), `each picture is bounded below FRAMED_IMAGE's own 420px cap, which the 400x1200 stub above would otherwise land exactly on (were ${open.imgH.join(", ")})`)
+    // AT MOST what the same picture draws unpinned, never more. `<=` rather than `<` because the arms
+    // satisfy it from opposite sides: three tall stubs are squeezed well under 420 by the ceiling,
+    // while ONE is squeezed by nothing and comes to rest exactly ON it. Only the one-picture arm ever
+    // failed — at 764px in this viewport, i.e. the pin rendering a screenshot nearly twice the size
+    // the very same file draws in the bubble below it.
+    assert.ok(open.imgH.every((h) => h <= 420), `no picture outgrows FRAMED_IMAGE's own 420px cap, which the 400x1200 stub above renders at unpinned (were ${open.imgH.join(", ")})`)
     assert.ok(open.msgH <= open.ceiling, `the whole pinned ask stays under 85vh (was ${open.msgH}px of ${open.ceiling}px)`)
+    assert.deepEqual(errors, [])
   } finally {
     await browser.close()
   }

--- a/packages/web/src/stickyUserMessage.e2e.test.ts
+++ b/packages/web/src/stickyUserMessage.e2e.test.ts
@@ -23,7 +23,13 @@ const baseUrl = process.env.FRIZZ_STICKY_USER_MESSAGE_E2E_URL
 const WIDTH = 1800
 const HEIGHT = 1000
 
-test("the pinned ask collapses, expands on hover, and keeps its fade across hover cycles", {
+// BOTH renderers that can hold the pin, because they share the collapse hook and nothing else: a
+// bubble (`size=medium`) and the composed multi-block answer (`size=answers`), which is a bordered
+// card whose cap sits on its answer rows rather than on the card. Each carried its own copy of a
+// fade defect the other did not. The fixture renders `data-font="sans"` — the app's own default,
+// which the cap's `4lh` resolves against.
+for (const size of ["medium", "answers"]) {
+test(`the pinned ask (${size}) collapses, expands on hover, and keeps its fade across hover cycles`, {
   skip: !baseUrl,
   timeout: 60_000,
 }, async () => {
@@ -36,7 +42,7 @@ test("the pinned ask collapses, expands on hover, and keeps its fade across hove
     page.on("console", (m) => { if (m.type() === "error" && !/404|favicon/i.test(m.text())) errors.push(m.text()) })
     page.on("pageerror", (e) => errors.push(String(e)))
 
-    await page.goto(`${baseUrl}/sticky-user-message-fixture.html?surface=queue&size=medium`, { waitUntil: "networkidle0" })
+    await page.goto(`${baseUrl}/sticky-user-message-fixture.html?surface=queue&size=${size}`, { waitUntil: "networkidle0" })
     await page.waitForSelector("[data-transcript-sticky]")
 
     // `position: sticky` pins between an element's own flow offset and the end of its containing
@@ -59,6 +65,13 @@ test("the pinned ask collapses, expands on hover, and keeps its fade across hove
         overflowY: capped ? getComputedStyle(capped).overflowY : null,
         // The soft "there's more" cue. Present exactly while collapsed AND clipped.
         fades: band.querySelectorAll('[class*="bg-gradient-to-t"]').length,
+        // WHERE it ends, which is the whole point of it: the veil has to reach full opacity exactly
+        // at the clip, or the cut row of text shows through it.
+        fadeGap: (() => {
+          const fade = band.querySelector('[class*="bg-gradient-to-t"]')
+          if (!fade || !capped) return null
+          return Math.round((fade.getBoundingClientRect().bottom - capped.getBoundingClientRect().bottom) * 100) / 100
+        })(),
         // The pin must be the HUMAN's turn, never a wake or a sub-agent's report.
         holdsWake: Boolean(band.querySelector("[data-frizz-wake]")),
       }
@@ -75,6 +88,10 @@ test("the pinned ask collapses, expands on hover, and keeps its fade across hove
     assert.equal(collapsed.overflowY, "hidden", "a collapsed ask never scrolls — the wheel belongs to the transcript")
     assert.ok(collapsed.scrollH! > collapsed.clientH!, "this fixture must actually overflow, or the test proves nothing")
     assert.equal(collapsed.fades, 1, "a clipped ask wears the fade")
+    // The answers card hung its fade on the CARD, so it ended 16px (the card's `p-4`) below the clip
+    // and left the cut row under only 0.6 of the veil. It now lives inside the capped box, where
+    // `bottom-0` IS the clip line.
+    assert.equal(collapsed.fadeGap, 0, "the fade must end exactly where the content is cut")
     const capHeight = collapsed.clientH!
 
     await pointer("mouseover")
@@ -84,17 +101,30 @@ test("the pinned ask collapses, expands on hover, and keeps its fade across hove
     assert.equal(expanded.fades, 0, "nothing is clipped once it is open, so nothing fades")
 
     await pointer("mouseout")
+    // MID-COLLAPSE, ~a third of the way through the 200ms tween: the box is already clipping hard and
+    // has to be wearing the fade while it does. Measuring on the leave render alone reported "nothing
+    // overflows" (the box is still expanded in that task) and blanked the fade for the whole
+    // animation, so every mouse-leave flashed the bare hard cut this fade exists to hide.
+    await new Promise((r) => setTimeout(r, 80))
+    const collapsing = await probe()
+    assert.ok(collapsing.clientH! < expanded.clientH!, "the collapse is actually in flight at this point")
+    assert.ok(collapsing.scrollH! > collapsing.clientH!, "…and the box is clipping while it runs")
+    assert.equal(collapsing.fades, 1, "the fade stays on THROUGH the collapse, not just after it")
+
     await new Promise((r) => setTimeout(r, 700))
     const recollapsed = await probe()
     assert.equal(recollapsed.clientH, capHeight, "leaving returns it to the same cap")
     // THE REGRESSION: this read 0 before the transitionend re-measure, and stayed 0 forever after.
     assert.equal(recollapsed.fades, 1, "the fade must come back — a hard clip mid-word reads as broken")
 
+    assert.equal(recollapsed.fadeGap, 0, "and it comes back in the right place")
+
     assert.deepEqual(errors, [])
   } finally {
     await browser.close()
   }
 })
+}
 
 test("a scheduler wake never takes the pinned band, on either surface", {
   skip: !baseUrl,
@@ -133,6 +163,49 @@ test("a scheduler wake never takes the pinned band, on either surface", {
       assert.equal(seen.wakeRendersInFlow, true, `${surface}: the wake still renders, in flow, in order`)
       assert.ok(seen.bandHeight < 300, `${surface}: the pinned ask stays a band, not a wall (was ${seen.bandHeight}px)`)
     }
+  } finally {
+    await browser.close()
+  }
+})
+
+test("a hovered pinned card never grows past the 85vh ceiling", {
+  skip: !baseUrl,
+  timeout: 60_000,
+}, async () => {
+  const { default: puppeteer } = await import("puppeteer")
+  const browser = await puppeteer.launch({ headless: "new", args: ["--no-sandbox", "--force-color-profile=srgb"] })
+  try {
+    const page = await browser.newPage()
+    // A SHORT window is the only place this bites: the ceiling has to be smaller than the message for
+    // it to bound anything at all. 400px puts 85vh at 340px against ~358px of answers.
+    await page.setViewport({ width: 1200, height: 400, deviceScaleFactor: 1 })
+    await page.goto(`${baseUrl}/sticky-user-message-fixture.html?surface=queue&size=answers`, { waitUntil: "networkidle0" })
+    await page.waitForSelector("[data-answers-card]")
+
+    const measure = () => page.evaluate(() => {
+      const card = document.querySelector("[data-answers-card] > div")!
+      const capped = document.querySelector<HTMLElement>('[data-answers-card] [style*="max-height"]')!
+      return {
+        cardH: Math.round(card.getBoundingClientRect().height),
+        cappedH: Math.round(capped.getBoundingClientRect().height),
+        contentH: capped.scrollHeight,
+        ceiling: Math.round(window.innerHeight * 0.85),
+      }
+    })
+
+    await page.evaluate(() => {
+      document.querySelector("[data-answers-card]")!
+        .dispatchEvent(new MouseEvent("mouseover", { bubbles: true, relatedTarget: document.body }))
+    })
+    await new Promise((r) => setTimeout(r, 600))
+    const open = await measure()
+
+    assert.ok(open.contentH > open.ceiling, "this viewport must actually put the answers over the ceiling")
+    // THE CEILING BOUNDS THE CARD, and the capped box is only the answer ROWS inside it. Applying 85vh
+    // to the rows alone seated the hovered card at 85vh plus its chrome (head, `p-4`, border) — 402px
+    // in a 400px window, i.e. taller than the viewport the ceiling exists to protect.
+    assert.ok(open.cardH <= open.ceiling, `the whole card stays under 85vh (was ${open.cardH}px of ${open.ceiling}px)`)
+    assert.ok(open.cardH > open.cappedH, "…and it is genuinely the card being bounded, chrome included")
   } finally {
     await browser.close()
   }

--- a/packages/web/src/stickyUserMessage.e2e.test.ts
+++ b/packages/web/src/stickyUserMessage.e2e.test.ts
@@ -111,13 +111,15 @@ test(`the pinned ask (${size}) collapses, expands on hover, and keeps its fade a
     // fixed sleep is a false-green waiting to happen: overrun the tween on a loaded box and all three
     // assertions below pass against the SETTLED state, which is not what any of them are about. Frame
     // sampling instead makes "the tween was never observed in flight" its own loud failure.
-    const collapseFrames = await page.evaluate(async () => {
+    const collapseFrames = await page.evaluate(async (expandedH: number) => {
       const band = document.querySelector("[data-transcript-sticky]")!
       band.querySelector("[data-frizz-msg]")!
         .dispatchEvent(new MouseEvent("mouseout", { bubbles: true, relatedTarget: document.body }))
       const frames: { h: number; scrollH: number; fades: number }[] = []
       await new Promise<void>((done) => {
-        let last = -1
+        // Seeded from the height the box is LEAVING, so the "it stopped moving" counter cannot start
+        // advancing before the tween has begun and end the sampling early on a loaded machine.
+        let last = expandedH
         let unchanged = 0
         const tick = () => {
           const el = band.querySelector<HTMLElement>('[style*="max-height"]')
@@ -131,7 +133,7 @@ test(`the pinned ask (${size}) collapses, expands on hover, and keeps its fade a
         requestAnimationFrame(tick)
       })
       return frames
-    })
+    }, expanded.clientH!)
     // Strictly BETWEEN the two resting heights, so neither end state can satisfy it.
     const inFlight = collapseFrames.filter((f) => f.h < expanded.clientH! && f.h > capHeight)
     assert.ok(inFlight.length > 0, `the collapse was never caught in flight, so nothing below is being tested (${collapseFrames.length} frames)`)
@@ -243,7 +245,12 @@ test("a hovered pinned card never grows past the 85vh ceiling", {
   }
 })
 
-test("a pinned ask's pictures share the 85vh ceiling rather than clearing it", {
+// BOTH prose heights, because they exercise different halves of the budget. `short` is one line, so the
+// prose is the same height collapsed and expanded; `medium` grows 108px -> 360px on the same hover the
+// pictures are being sized for, which is the case a budget struck against a mid-transition read gets
+// wrong (measured 1101px in a 1000px window before the wrapper was observed).
+for (const size of ["short", "medium"]) {
+test(`a pinned ask's pictures share the 85vh ceiling rather than clearing it (${size} prose)`, {
   skip: !baseUrl,
   timeout: 60_000,
 }, async () => {
@@ -270,7 +277,7 @@ test("a pinned ask's pictures share the 85vh ceiling rather than clearing it", {
     })
 
     const paths = ["/tmp/shot-a.png", "/tmp/shot-b.png", "/tmp/shot-c.png"].join(",")
-    await page.goto(`${baseUrl}/sticky-user-message-fixture.html?surface=queue&size=short&img=${paths}`, { waitUntil: "networkidle0" })
+    await page.goto(`${baseUrl}/sticky-user-message-fixture.html?surface=queue&size=${size}&img=${paths}`, { waitUntil: "networkidle0" })
     await page.waitForSelector("[data-transcript-sticky] img")
 
     const measure = () => page.evaluate(() => {
@@ -301,9 +308,10 @@ test("a pinned ask's pictures share the 85vh ceiling rather than clearing it", {
     // 101.7% of a 1000px window and 145.4% of a 700px one, the pinned element hiding the transcript it
     // is pinned above. They now split what the ceiling leaves them.
     assert.ok(open.imgH.every((h) => h > shut.imgH[0]!), "hovering still grows the pictures")
-    assert.ok(open.imgH.every((h) => h < 420), `each picture is bounded BELOW the frame's own 420px cap (were ${open.imgH.join(", ")})`)
+    assert.ok(open.imgH.every((h) => h < 420), `each picture is bounded below FRAMED_IMAGE's own 420px cap, which the 400x1200 stub above would otherwise land exactly on (were ${open.imgH.join(", ")})`)
     assert.ok(open.msgH <= open.ceiling, `the whole pinned ask stays under 85vh (was ${open.msgH}px of ${open.ceiling}px)`)
   } finally {
     await browser.close()
   }
 })
+}

--- a/packages/web/src/stickyUserMessage.e2e.test.ts
+++ b/packages/web/src/stickyUserMessage.e2e.test.ts
@@ -90,7 +90,10 @@ test(`the pinned ask (${size}) collapses, expands on hover, and keeps its fade a
     assert.equal(collapsed.fades, 1, "a clipped ask wears the fade")
     // The answers card hung its fade on the CARD, so it ended 16px (the card's `p-4`) below the clip
     // and left the cut row under only 0.6 of the veil. It now lives inside the capped box, where
-    // `bottom-0` IS the clip line.
+    // `bottom-0` IS the clip line. THE `answers` ARM IS THE LOAD-BEARING ONE: the bubble's fade has
+    // always been a `bottom-0` child of the capped bubble itself, so its gap is structurally 0 and
+    // nothing short of moving the element could make this fail there. Kept in the loop anyway — it is
+    // free, and it is the invariant both renderers are now supposed to share.
     assert.equal(collapsed.fadeGap, 0, "the fade must end exactly where the content is cut")
     const capHeight = collapsed.clientH!
 
@@ -100,16 +103,40 @@ test(`the pinned ask (${size}) collapses, expands on hover, and keeps its fade a
     assert.ok(expanded.clientH! > capHeight, "hovering opens the ask to its full height")
     assert.equal(expanded.fades, 0, "nothing is clipped once it is open, so nothing fades")
 
-    await pointer("mouseout")
-    // MID-COLLAPSE, ~a third of the way through the 200ms tween: the box is already clipping hard and
-    // has to be wearing the fade while it does. Measuring on the leave render alone reported "nothing
-    // overflows" (the box is still expanded in that task) and blanked the fade for the whole
-    // animation, so every mouse-leave flashed the bare hard cut this fade exists to hide.
-    await new Promise((r) => setTimeout(r, 80))
-    const collapsing = await probe()
-    assert.ok(collapsing.clientH! < expanded.clientH!, "the collapse is actually in flight at this point")
-    assert.ok(collapsing.scrollH! > collapsing.clientH!, "…and the box is clipping while it runs")
-    assert.equal(collapsing.fades, 1, "the fade stays on THROUGH the collapse, not just after it")
+    // MID-COLLAPSE. Measuring on the leave render alone reported "nothing overflows" (the box is still
+    // expanded in that task) and blanked the fade for the whole 200ms animation, so every mouse-leave
+    // flashed the bare hard cut this fade exists to hide.
+    //
+    // Sampled EVERY FRAME from inside the page rather than by sleeping a constant and probing once. A
+    // fixed sleep is a false-green waiting to happen: overrun the tween on a loaded box and all three
+    // assertions below pass against the SETTLED state, which is not what any of them are about. Frame
+    // sampling instead makes "the tween was never observed in flight" its own loud failure.
+    const collapseFrames = await page.evaluate(async () => {
+      const band = document.querySelector("[data-transcript-sticky]")!
+      band.querySelector("[data-frizz-msg]")!
+        .dispatchEvent(new MouseEvent("mouseout", { bubbles: true, relatedTarget: document.body }))
+      const frames: { h: number; scrollH: number; fades: number }[] = []
+      await new Promise<void>((done) => {
+        let last = -1
+        let unchanged = 0
+        const tick = () => {
+          const el = band.querySelector<HTMLElement>('[style*="max-height"]')
+          const h = el?.clientHeight ?? -1
+          frames.push({ h, scrollH: el?.scrollHeight ?? -1, fades: band.querySelectorAll('[class*="bg-gradient-to-t"]').length })
+          unchanged = h === last ? unchanged + 1 : 0
+          last = h
+          if (unchanged >= 5 || frames.length > 240) return done()
+          requestAnimationFrame(tick)
+        }
+        requestAnimationFrame(tick)
+      })
+      return frames
+    })
+    // Strictly BETWEEN the two resting heights, so neither end state can satisfy it.
+    const inFlight = collapseFrames.filter((f) => f.h < expanded.clientH! && f.h > capHeight)
+    assert.ok(inFlight.length > 0, `the collapse was never caught in flight, so nothing below is being tested (${collapseFrames.length} frames)`)
+    assert.ok(inFlight.every((f) => f.scrollH > f.h), "every mid-tween frame is clipping — that is what the fade is for")
+    assert.equal(inFlight.filter((f) => f.fades !== 1).length, 0, "the fade stays on THROUGH the collapse, not just after it")
 
     await new Promise((r) => setTimeout(r, 700))
     const recollapsed = await probe()
@@ -177,8 +204,10 @@ test("a hovered pinned card never grows past the 85vh ceiling", {
   try {
     const page = await browser.newPage()
     // A SHORT window is the only place this bites: the ceiling has to be smaller than the message for
-    // it to bound anything at all. 400px puts 85vh at 340px against ~358px of answers.
-    await page.setViewport({ width: 1200, height: 400, deviceScaleFactor: 1 })
+    // it to bound anything at all. 320px puts 85vh at 272px against ~358px of answers — a 32% margin,
+    // deliberately not the 400px (5%) this started at, because the premise is measuring RENDERED TEXT
+    // and a font fallback on someone else's machine should not turn it red.
+    await page.setViewport({ width: 1200, height: 320, deviceScaleFactor: 1 })
     await page.goto(`${baseUrl}/sticky-user-message-fixture.html?surface=queue&size=answers`, { waitUntil: "networkidle0" })
     await page.waitForSelector("[data-answers-card]")
 
@@ -205,7 +234,75 @@ test("a hovered pinned card never grows past the 85vh ceiling", {
     // to the rows alone seated the hovered card at 85vh plus its chrome (head, `p-4`, border) — 402px
     // in a 400px window, i.e. taller than the viewport the ceiling exists to protect.
     assert.ok(open.cardH <= open.ceiling, `the whole card stays under 85vh (was ${open.cardH}px of ${open.ceiling}px)`)
-    assert.ok(open.cardH > open.cappedH, "…and it is genuinely the card being bounded, chrome included")
+    // The discriminator, and the only other line here that can fail: bounding the ROWS puts the rows
+    // box exactly ON the ceiling, and bounding the CARD leaves them short of it by the chrome. (That
+    // the card is taller than the rows it contains is true by construction and worth asserting nowhere.)
+    assert.ok(open.cappedH < open.ceiling, `the rows stop short of the ceiling to leave room for the chrome (rows ${open.cappedH}px, ceiling ${open.ceiling}px)`)
+  } finally {
+    await browser.close()
+  }
+})
+
+test("a pinned ask's pictures share the 85vh ceiling rather than clearing it", {
+  skip: !baseUrl,
+  timeout: 60_000,
+}, async () => {
+  const { default: puppeteer } = await import("puppeteer")
+  const browser = await puppeteer.launch({ headless: "new", args: ["--no-sandbox", "--force-color-profile=srgb"] })
+  try {
+    const page = await browser.newPage()
+    await page.setViewport({ width: 1400, height: 1000, deviceScaleFactor: 1 })
+    // The attachments are real `/local-image` requests for real absolute paths — the fixture spells a
+    // send exactly the way the composer does — so the pictures are served here rather than the fixture
+    // being taught to fake them. Deliberately TALLER than it is wide: unconstrained, each one renders
+    // at FRAMED_IMAGE's flat `max-h-[420px]`, and three of those clear an 850px ceiling on their own.
+    await page.setRequestInterception(true)
+    page.on("request", (req) => {
+      // Matched by the `path=` query the image route takes rather than by the route's NAME: a bare
+      // route literal in this package's source is exactly what lib/frizzRouteUrls.test.ts forbids, and
+      // that guard cannot tell a URL being matched from one being built.
+      if (!new URL(req.url()).searchParams.has("path")) return req.continue()
+      req.respond({
+        status: 200,
+        contentType: "image/svg+xml",
+        body: '<svg xmlns="http://www.w3.org/2000/svg" width="400" height="1200"><rect width="100%" height="100%" fill="#456"/></svg>',
+      })
+    })
+
+    const paths = ["/tmp/shot-a.png", "/tmp/shot-b.png", "/tmp/shot-c.png"].join(",")
+    await page.goto(`${baseUrl}/sticky-user-message-fixture.html?surface=queue&size=short&img=${paths}`, { waitUntil: "networkidle0" })
+    await page.waitForSelector("[data-transcript-sticky] img")
+
+    const measure = () => page.evaluate(() => {
+      const band = document.querySelector("[data-transcript-sticky]")!
+      const msg = band.querySelector("[data-frizz-msg]")!
+      return {
+        ceiling: Math.round(window.innerHeight * 0.85),
+        msgH: Math.round(msg.getBoundingClientRect().height),
+        imgH: [...msg.querySelectorAll("img")].map((i) => Math.round(i.getBoundingClientRect().height)),
+      }
+    })
+
+    const shut = await measure()
+    // Collapsed is the half that already worked, and the picture ceiling must not disturb it: three
+    // screenshots still cost ONE band of thumbnails, not three.
+    assert.equal(shut.imgH.length, 3)
+    assert.ok(shut.msgH < 250, `collapsed, three pictures are one thumbnail row (was ${shut.msgH}px)`)
+
+    await page.evaluate(() => {
+      document.querySelector("[data-transcript-sticky] [data-frizz-msg]")!
+        .dispatchEvent(new MouseEvent("mouseover", { bubbles: true, relatedTarget: document.body }))
+    })
+    await new Promise((r) => setTimeout(r, 700))
+    const open = await measure()
+
+    // THE DEFECT: `useStickyCollapse` bounds the box it caps, and for a bubble that is the prose only —
+    // the pictures are its siblings. Hovering a pinned ask with three screenshots opened the band to
+    // 101.7% of a 1000px window and 145.4% of a 700px one, the pinned element hiding the transcript it
+    // is pinned above. They now split what the ceiling leaves them.
+    assert.ok(open.imgH.every((h) => h > shut.imgH[0]!), "hovering still grows the pictures")
+    assert.ok(open.imgH.every((h) => h < 420), `each picture is bounded BELOW the frame's own 420px cap (were ${open.imgH.join(", ")})`)
+    assert.ok(open.msgH <= open.ceiling, `the whole pinned ask stays under 85vh (was ${open.msgH}px of ${open.ceiling}px)`)
   } finally {
     await browser.close()
   }

--- a/packages/web/src/stickyUserMessage.e2e.test.ts
+++ b/packages/web/src/stickyUserMessage.e2e.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+// Runtime coverage for THE PINNED ASK'S COLLAPSE, which only a browser can settle: the cap is
+// `calc(4lh + …)` (a resolved-font unit no unit test can evaluate), the fade is gated on a live
+// `scrollHeight`/`clientHeight` read, and the defect this file exists for is a STATE TRANSITION —
+// the first paint is correct and only the post-hover state is wrong, which is exactly what a
+// one-shot screenshot pass cannot see.
+//
+// What went wrong: `measure()` on the mouse-leave RENDER reads a box still mid-transition, because
+// max-height animates length→length and `clientHeight` is still the EXPANDED height in that task.
+// For any ask shorter than the 85vh cap, expanded clientHeight IS scrollHeight, so the overflow test
+// read false; `Message` is memoized, so nothing ever re-measured, and the pinned ask stayed
+// hard-clipped mid-word with no fade for the rest of the session. Reproduced on the queue card at
+// 1800x1000 with a 528px ask before `onCapTransitionEnd` began re-measuring.
+//
+// Skipped unless a Vite URL serving the fixtures is provided (same pattern as the other *.e2e.test.ts
+// here): start `vite` in packages/web and set FRIZZ_STICKY_USER_MESSAGE_E2E_URL to its origin.
+const baseUrl = process.env.FRIZZ_STICKY_USER_MESSAGE_E2E_URL
+
+// The queue card at this width gives the pinned bubble a 528px message — over the four-line cap and
+// UNDER the 85vh expanded cap, which is the only band where the latch bit.
+const WIDTH = 1800
+const HEIGHT = 1000
+
+test("the pinned ask collapses, expands on hover, and keeps its fade across hover cycles", {
+  skip: !baseUrl,
+  timeout: 60_000,
+}, async () => {
+  const { default: puppeteer } = await import("puppeteer")
+  const browser = await puppeteer.launch({ headless: "new", args: ["--no-sandbox", "--force-color-profile=srgb"] })
+  try {
+    const page = await browser.newPage()
+    await page.setViewport({ width: WIDTH, height: HEIGHT, deviceScaleFactor: 1 })
+    const errors: string[] = []
+    page.on("console", (m) => { if (m.type() === "error" && !/404|favicon/i.test(m.text())) errors.push(m.text()) })
+    page.on("pageerror", (e) => errors.push(String(e)))
+
+    await page.goto(`${baseUrl}/sticky-user-message-fixture.html?surface=queue&size=medium`, { waitUntil: "networkidle0" })
+    await page.waitForSelector("[data-transcript-sticky]")
+
+    // `position: sticky` pins between an element's own flow offset and the end of its containing
+    // block, so the band only engages once the pane is scrolled past it — which is where a reader
+    // sits, at the end of the transcript.
+    await page.evaluate(() => {
+      const band = document.querySelector("[data-transcript-sticky]")!
+      let pane = band.parentElement
+      while (pane && pane.scrollHeight <= pane.clientHeight + 4) pane = pane.parentElement
+      if (pane) pane.scrollTop = pane.scrollHeight
+    })
+    await new Promise((r) => setTimeout(r, 200))
+
+    const probe = () => page.evaluate(() => {
+      const band = document.querySelector("[data-transcript-sticky]")!
+      const capped = band.querySelector<HTMLElement>('[style*="max-height"]')
+      return {
+        clientH: capped?.clientHeight ?? null,
+        scrollH: capped?.scrollHeight ?? null,
+        overflowY: capped ? getComputedStyle(capped).overflowY : null,
+        // The soft "there's more" cue. Present exactly while collapsed AND clipped.
+        fades: band.querySelectorAll('[class*="bg-gradient-to-t"]').length,
+        // The pin must be the HUMAN's turn, never a wake or a sub-agent's report.
+        holdsWake: Boolean(band.querySelector("[data-frizz-wake]")),
+      }
+    })
+    // React synthesizes enter/leave from delegated mouseover/mouseout, so a dispatched `mouseenter`
+    // would not reach the handler.
+    const pointer = (type: "mouseover" | "mouseout") => page.evaluate((t) => {
+      const target = document.querySelector("[data-transcript-sticky] [data-frizz-msg]")!
+      target.dispatchEvent(new MouseEvent(t, { bubbles: true, relatedTarget: document.body }))
+    }, type)
+
+    const collapsed = await probe()
+    assert.equal(collapsed.holdsWake, false)
+    assert.equal(collapsed.overflowY, "hidden", "a collapsed ask never scrolls — the wheel belongs to the transcript")
+    assert.ok(collapsed.scrollH! > collapsed.clientH!, "this fixture must actually overflow, or the test proves nothing")
+    assert.equal(collapsed.fades, 1, "a clipped ask wears the fade")
+    const capHeight = collapsed.clientH!
+
+    await pointer("mouseover")
+    await new Promise((r) => setTimeout(r, 500))
+    const expanded = await probe()
+    assert.ok(expanded.clientH! > capHeight, "hovering opens the ask to its full height")
+    assert.equal(expanded.fades, 0, "nothing is clipped once it is open, so nothing fades")
+
+    await pointer("mouseout")
+    await new Promise((r) => setTimeout(r, 700))
+    const recollapsed = await probe()
+    assert.equal(recollapsed.clientH, capHeight, "leaving returns it to the same cap")
+    // THE REGRESSION: this read 0 before the transitionend re-measure, and stayed 0 forever after.
+    assert.equal(recollapsed.fades, 1, "the fade must come back — a hard clip mid-word reads as broken")
+
+    assert.deepEqual(errors, [])
+  } finally {
+    await browser.close()
+  }
+})
+
+test("a scheduler wake never takes the pinned band, on either surface", {
+  skip: !baseUrl,
+  timeout: 60_000,
+}, async () => {
+  const { default: puppeteer } = await import("puppeteer")
+  const browser = await puppeteer.launch({ headless: "new", args: ["--no-sandbox", "--force-color-profile=srgb"] })
+  try {
+    const page = await browser.newPage()
+    await page.setViewport({ width: 1440, height: 900, deviceScaleFactor: 1 })
+    // Both surfaces pin from their own call site, and they carried this defect independently until
+    // both were pointed at `lastAskIndex` — so both are asserted here.
+    for (const surface of ["queue", "drawer"]) {
+      await page.goto(`${baseUrl}/sticky-user-message-fixture.html?surface=${surface}&size=wake`, { waitUntil: "networkidle0" })
+      await page.waitForSelector("[data-transcript-sticky]")
+      await page.evaluate(() => {
+        const band = document.querySelector("[data-transcript-sticky]")!
+        let pane = band.parentElement
+        while (pane && pane.scrollHeight <= pane.clientHeight + 4) pane = pane.parentElement
+        if (pane) pane.scrollTop = pane.scrollHeight
+      })
+      await new Promise((r) => setTimeout(r, 200))
+      const seen = await page.evaluate(() => {
+        const band = document.querySelector("[data-transcript-sticky]")!
+        const wake = document.querySelector("[data-frizz-wake]")
+        return {
+          bandHeight: Math.round(band.getBoundingClientRect().height),
+          bandHoldsWake: Boolean(band.querySelector("[data-frizz-wake]")),
+          wakeRendersInFlow: Boolean(wake) && !wake!.closest("[data-transcript-sticky]"),
+        }
+      })
+      // Before the `wake` guard this band was the full height of the pane, holding the whole
+      // delivered prompt over the transcript (maintainer 2026-08-21: "this dialog covers the entire
+      // chat contents").
+      assert.equal(seen.bandHoldsWake, false, `${surface}: the band holds the human's ask, not frizz's own turn`)
+      assert.equal(seen.wakeRendersInFlow, true, `${surface}: the wake still renders, in flow, in order`)
+      assert.ok(seen.bandHeight < 300, `${surface}: the pinned ask stays a band, not a wall (was ${seen.bandHeight}px)`)
+    }
+  } finally {
+    await browser.close()
+  }
+})


### PR DESCRIPTION
## The symptom

A one-off timer fired on a thread, and its delivered prompt took over the whole chat: the pinned
current-ask band drew the entire wake as a card floating over the transcript, and nothing underneath
was readable.

> this dialog covers the entire chat contents. and I can't read the contents.

Measured on `sticky-user-message-fixture` at 1440x900 against current `main`: the pinned band is
**900px tall in a 900px drawer pane**, and **620px on the queue card**. Both surfaces, independently.

## Mechanism

Two defects that meet in the same band.

**1. The band picks a message frizz wrote.** `lastAskIndex` chooses what pins. It already excluded a
queued follow-up and a sub-agent's upward report, but not a **wake** — frizz's own turn, recorded as
a `user` row because the scheduler pastes it into the worker's composer. So a delivered wake wins the
pin. Unlike a bubble it ignores `sticky` entirely: a wake whose prose no parser in `FrizzWake`
recognizes takes the uncapped fallback `TranscriptCard`, and that is what floats. The wakes that *do*
parse draw a one-line divider — a quieter symptom of the identical defect, since a hairline pinned in
the ask band is still standing where the human's instruction should be.

`TodosView` carried the same bug independently, through its own duplicate `role === "user" && !queued`
walk, so the queue card reproduced it unchanged.

**2. Nothing caps what the band draws.** The sticky wrapper deliberately imposes no ceiling — it is
transparent and unclipped, because a scroller there would eat the wheel over the content to its left
and a clip cannot keep the collapsed bubble's rounded corners. So each renderer that can hold the pin
has to cap itself, and only `UserBubble` did:

* `AnswersCard` — which legitimately *is* the current ask — had no cap at all, so answering several
  questions with pasted paragraphs floated an unbounded card.
* the bubble's own cap was a flat `200px` (~8 lines of a 14px font), and it did not cover
  **attachments**, which render as the bubble's *siblings*. A 420px screenshot hung under the capped
  bubble and floated at full size on every scroll.

## The change

* `lastAskIndex` drops `wake` too, and `TodosView` pins on it instead of its own walk. That walk stays
  for the queue card's **collapse anchor**, which asks something weaker — is there any landed user row
  above the first fold — and a wake row is one whether or not it is pinned. Folding the two together
  would silently switch collapsing off on a wake-driven card.
* the collapse moves into a shared `useStickyCollapse(sticky, padY)`, so the answers card gets it too.
  The cap is `calc(4lh + <the caller's own padding>)` — four line boxes of the **resolved** font, so it
  tracks the prose/mono setting and the type scale with nothing to re-measure. The padding is the
  caller's because `max-height` is a border-box measurement and the bubble (`py-3`) and the card
  (`p-4`) do not agree on it.
* collapsed attachments become a single **non-wrapping** row of thumbnails that shrink to fit, so N
  pictures cost one band of height at any band width. `flex-wrap` was the first attempt and is a trap
  here: the max-content size of a multi-line flex container is its widest *item*, so inside this
  shrink-to-fit column the row collapsed to one thumb's width and every picture took its own line —
  three screenshots came to 474px in a 437px pane, i.e. the defect the row exists to fix.
* hovering expands the whole message, pictures included. The hover handlers hang on the message
  wrapper rather than the bubble, because the attachments are outside the bubble: hung on it, reaching
  for a pinned screenshot collapsed the thing you were reaching for.

## Verification

Driven in real Chrome on **both** surfaces through `sticky-user-message-fixture`, which gains
`?size=wake`, `?size=answers` and `?img=<abs path>`.

| | before | after |
|---|---|---|
| pinned band, drawer, wake last | 900px in a 900px pane, holding the wake | **105px**, holding the human's ask; the 882px wake card in flow beneath |
| pinned band, queue card, wake last | 620px, holding the wake | **84px**, holding the human's ask |
| 3804px ask, collapsed | 200px, hard cap | **108px** box, fade shown, `overflow: hidden` |
| 3804px ask, hovered | — | **765px** (85vh), `overflow-y: auto`, scrolls |
| answers card, 665px of content | uncapped | **110px**, fade shown |
| ask + 3 screenshots, collapsed | ~1430px | **242px** (one thumb row), falling to 203px in a 403px-wide band as the thumbs shrink |

Historical (non-sticky) bubbles stay uncapped and unclipped, and `?sticky=off` still pins nothing.

`pnpm typecheck` is clean. The full `pnpm test` suite was run against this branch **and against
pristine `main` as a control**: 3700 tests with an identical set of 155 failures on both — all
socket-bound server tests my sandbox cannot run, none touching this change. The new `lastAskIndex`
assertions were confirmed red without the guard (`actual: 2, expected: 0`).

The three CI checks: `node --test board/*.test.mjs` 73/73 green, `node scripts/sync-portable-monitors.mjs --check`
clean, and `node --test monitors/*.test.mjs` 15/16 — that one failure reproduces unchanged on pristine
`main` (it asserts on the dispatched worker prompt, unrelated to this diff).
