### PR TITLE
fix(claude-sdk): an environment key is what the OS can carry, not a POSIX shell identifier - Windows dispatch died on ProgramFiles(x86)

### DIFF
--- a/packages/server/src/backend/claude-agent-sdk.test.ts
+++ b/packages/server/src/backend/claude-agent-sdk.test.ts
@@ -1220,6 +1220,25 @@ test("input, JSON, environment, and executable boundaries reject unsafe payloads
   }
 })
 
+test("a Windows-shaped environment key — ProgramFiles(x86) — is a valid override and the session starts", { timeout: 10_000 }, async () => {
+  // Every 64-bit Windows box carries `ProgramFiles(x86)` and `CommonProgramFiles(x86)`, and the broker
+  // daemon hands the WHOLE inherited environment to start() as overrides (claude-agent-broker.ts). The
+  // key rule used to be a POSIX shell identifier, so the daemon threw "invalid key" on startup, never
+  // published its record, and every Claude dispatch on Windows timed out with "did not become ready"
+  // (measured on Windows Server 2022, frizz 0.8.1, 2026-09-01). The OS accepts any name without `=` or
+  // NUL; that is the rule now. The malformed-key guard above (`INVALID=KEY`) still holds.
+  const harness = startHarness("windows-env-key", {
+    "ProgramFiles(x86)": "C:\\Program Files (x86)",
+    "CommonProgramFiles(x86)": "C:\\Program Files (x86)\\Common Files",
+  })
+  try {
+    const ready = await withTimeout(harness.handle.ready(), "session init")
+    assert.equal(ready.sessionId, SESSION_ID)
+  } finally {
+    await harness.close()
+  }
+})
+
 function startHarness(
   scenario: string,
   env: Record<string, string | undefined> = {},

--- a/packages/server/src/backend/claude-agent-sdk.ts
+++ b/packages/server/src/backend/claude-agent-sdk.ts
@@ -62,7 +62,17 @@ const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3
 // canary that guards it cannot drift apart. It is real at runtime but missing from the SDK's `.d.ts`,
 // so nothing in the type system would notice it disappearing — see claude-agent-sdk.cancel.test.ts.
 export const CLAUDE_SDK_CANCEL_METHOD = "cancelAsyncMessage"
-const ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/
+// What the OS can carry in an environment block: a non-empty name with no `=` and no NUL. NOT a POSIX
+// shell identifier, which is what this was until 2026-09-01 (`/^[A-Za-z_][A-Za-z0-9_]*$/`). Every
+// 64-bit Windows environment contains `ProgramFiles(x86)` and `CommonProgramFiles(x86)`, and the
+// broker daemon passes the whole inherited environment to buildEnvironment() as overrides — so on
+// Windows the daemon threw here on startup, never published its record, and every Claude dispatch
+// timed out with "did not become ready" (measured on Windows Server 2022, frizz 0.8.1: three broker
+// deaths in a row, each `uncaught-exception: Claude environment contains an invalid key`). Node
+// itself spawns a child with such a key without complaint; only this check refused it. cmd.exe's
+// hidden `=C:` drive variables never reach process.env (node drops them), so a leading `=` needs no
+// special case.
+const ENV_KEY_PATTERN = /^[^=\0]+$/
 const SENSITIVE_ENV_KEY = /(?:API_KEY|AUTH|BASE_URL|BEARER|COOKIE|CREDENTIAL|OAUTH|PASSWORD|PRIVATE|SECRET|TOKEN)/i
 const MAX_ENV_ENTRIES = 512
 const MAX_ENV_VALUE_BYTES = 128 * 1024


### PR DESCRIPTION
## The bug

On Windows, every Claude prompt fails in the browser with:

> Claude session broker could not start this thread: Claude broker for session … did not become ready

The broker daemon's own diagnostics log names the cause (Windows Server 2022, frizz 0.8.1, node 24.15; three attempts, three identical deaths):

```
uncaught-exception: ClaudeAgentSdkProtocolError: Claude environment contains an invalid key
    at buildEnvironment (dist/claude-agent-broker.js:21371)
```

The daemon hands `start()` the whole inherited environment as overrides (`claude-agent-broker.ts:152`), and `buildEnvironment()` checks every override key against `ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/`. Every 64-bit Windows environment contains `ProgramFiles(x86)` and `CommonProgramFiles(x86)`, so the daemon throws during startup, never publishes its record, and `forkBroker()` times out.

The guard was written for "a bounded handful" of frizz's own keys and treats a malformed one as a frizz bug. On this path it is judging the operator's shell, whose names the OS already accepted. Node spawns a child with such a key without complaint (measured: the child reads it back).

## The fix

The pattern is now the OS rule: a non-empty name with no `=` and no NUL (`/^[^=\0]+$/`). cmd.exe's hidden `=C:` drive variables never reach `process.env` (node drops them), so a leading `=` needs no special case. The existing `INVALID=KEY` guard still throws, and the too-short-secret and must-be-text guards are untouched.

## Evidence

- New test in `claude-agent-sdk.test.ts`: a session whose overrides carry `ProgramFiles(x86)` reaches init. It fails on the old pattern with the exact production error and passes on the new one.
- Typecheck (shared, rpc, server) green; the file's suite green apart from one pre-existing environmental failure (`CLAUDE_CODE_ENTRYPOINT=cli` inherited when the suite runs inside a Claude Code shell — untouched here).
- Verified live on Windows: with this one line patched into the 0.8.1 bundle, dispatch works and the broker daemons stay up.

Scope note: the change is in a Claude-only code path and was verified with the Claude Code backend on Windows. Companion Windows fix (independent, both needed for a working Windows experience): #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bj6zyZAbgahx4JD7SYJmZz
