### PR TITLE
fix(project): cwdSlug is Claude Code's rule - every non-alphanumeric becomes '-' - so a Windows path finds its transcript

### DIFF
--- a/packages/server/src/discover.ts
+++ b/packages/server/src/discover.ts
@@ -113,7 +113,7 @@ export function discoverTranscriptId(logDir: string, sessionId: string, opts: Di
 //
 // Everything above assumes the transcript is SOMEWHERE IN `logDir`. That assumption breaks the moment
 // the operator renames or moves the checkout, because Claude Code shards its store by the cwd a session
-// was BORN in — `~/.claude/projects/<cwd with / and . replaced by ->/` — and a resumed session KEEPS
+// was BORN in — `~/.claude/projects/<cwd with every non-alphanumeric character replaced by ->/` — and a resumed session KEEPS
 // WRITING TO ITS BIRTH BUCKET FOREVER. Frizz derives that bucket from the project's CURRENT path
 // (project.ts cwdSlug), so after a rename every pre-existing thread points at a file that will never
 // exist, the crash-net reads it as "no transcript after 60s — likely a boot failure", and the board

--- a/packages/server/src/project.test.ts
+++ b/packages/server/src/project.test.ts
@@ -3,7 +3,20 @@ import assert from "node:assert/strict"
 import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { parseRepoLabel, projectFromRegistryEntry } from "./project.ts"
+import { cwdSlug, parseRepoLabel, projectFromRegistryEntry } from "./project.ts"
+
+test("cwdSlug: every non-alphanumeric character becomes '-', on every platform", () => {
+  // The rule Claude Code applies to the cwd to name ~/.claude/projects/<slug>. Every expectation here
+  // is a directory name measured on disk, not derived. The old rule replaced only '/' and '.', which
+  // left a Windows path untouched — `D:\Development\Feature3` stayed `D:\Development\Feature3` — so the
+  // tailer watched a path that never existed, raised "no transcript 60s after dispatch — likely a boot
+  // failure" and marked every Windows thread dead while claude was still working (Windows Server 2022,
+  // frizz 0.8.1, 2026-09-01). The same rule also mis-slugs '_' and ' ' on POSIX.
+  assert.equal(cwdSlug("/Users/x/.workshell"), "-Users-x--workshell")
+  assert.equal(cwdSlug("D:\\Development\\Feature3"), "D--Development-Feature3")
+  assert.equal(cwdSlug("D:\\Development\\frizz\\slug_probe dir"), "D--Development-frizz-slug-probe-dir")
+  assert.equal(cwdSlug("/home/x/my_repo v2"), "-home-x-my-repo-v2")
+})
 
 test("parseRepoLabel: scp-like ssh with .git", () => {
   assert.equal(parseRepoLabel("git@github.com:owner/repo.git"), "owner/repo")

--- a/packages/server/src/project.ts
+++ b/packages/server/src/project.ts
@@ -148,11 +148,20 @@ function resolveProjectIdentity(
   return { id: ensureProjectIdFile(root, home, git?.id), scope: git?.scope ?? "repository", root }
 }
 
-// Claude Code's per-project session-log dir name: the absolute cwd with every '/' and '.'
-// replaced by '-'. Verified empirically against ~/.claude/projects (e.g. /Users/x/.workshell
-// → -Users-x--workshell). Used later by the JSONL tailer; computed here so the rule lives once.
+// Claude Code's per-project session-log dir name: the absolute cwd with every character that is not
+// A–Z, a–z or 0–9 replaced by '-'. Verified empirically against ~/.claude/projects on both platforms:
+// /Users/x/.workshell → -Users-x--workshell, D:\Development\Feature3 → D--Development-Feature3, and
+// D:\Development\frizz\slug_probe dir → D--Development-frizz-slug-probe-dir (claude 2.1.257).
+//
+// Until 2026-09-01 this replaced only '/' and '.', which is the same thing for a plain POSIX path and
+// a different thing for everything else. A Windows path has neither, so it came back UNCHANGED and the
+// tailer watched ~/.claude/projects/D:\Development\Feature3/<id>.jsonl — a path that never exists.
+// Sixty seconds later every Windows thread was reported as "no transcript 60s after dispatch — likely
+// a boot failure" and shown dead on the board, while claude was still mid-turn in a transcript frizz
+// never opened. '_' and ' ' in a POSIX path went wrong the same way, just more rarely.
+// Used later by the JSONL tailer; computed here so the rule lives once.
 export function cwdSlug(absPath: string): string {
-  return absPath.replace(/[/.]/g, "-")
+  return absPath.replace(/[^A-Za-z0-9]/g, "-")
 }
 
 // The repo-label helpers moved to project-identity.ts, which is an exported subpath: the LAUNCHER

--- a/packages/server/src/server.test.ts
+++ b/packages/server/src/server.test.ts
@@ -418,7 +418,7 @@ test("adopt: requires the legacy file, provisions a scratch dir, orientation is 
   assert.equal(row?.permission_mode, "bypassPermissions", "adoption pins the concrete launch permission")
 })
 
-test("cwdSlug: replaces / and . with - (Claude Code project-log convention)", () => {
+test("cwdSlug: replaces every non-alphanumeric character with - (Claude Code project-log convention)", () => {
   assert.equal(cwdSlug("/Users/x/Documents/projects/frizz"), "-Users-x-Documents-projects-frizz")
   assert.equal(cwdSlug("/Users/x/.workshell/wt"), "-Users-x--workshell-wt")
 })


### PR DESCRIPTION
## The bug

On Windows a thread's agent runs to completion while the board reports it dead. Sixty seconds after each dispatch the tailer logs:

> no transcript 60s after dispatch — likely a boot failure

(Windows Server 2022, frizz 0.8.1, claude 2.1.257.) Yet the transcript is on disk and growing at `~/.claude/projects/D--Development-Feature3/<id>.jsonl`. frizz is watching `~/.claude/projects/D:\Development\Feature3/<id>.jsonl` instead.

`cwdSlug()` replaces only `/` and `.` — the two characters a plain POSIX path contains. Claude Code's rule is wider: every character that is not `A–Z`, `a–z` or `0–9` becomes `-`. The two rules agree on `/Users/x/.workshell` (the case the comment cited) and on nothing else. A Windows path has neither `/` nor `.`, so it comes back unchanged; a POSIX path with `_` or a space goes wrong the same way, just more rarely.

## The fix

The rule is now `/[^A-Za-z0-9]/g → '-'`. Measured, not derived:

| cwd | Claude Code's folder |
|---|---|
| `/Users/x/.workshell` | `-Users-x--workshell` (the existing case) |
| `D:\Development\Feature3` | `D--Development-Feature3` (every project dir on the affected box) |
| `D:\Development\frizz\slug_probe dir` | `D--Development-frizz-slug-probe-dir` (a probe run of `claude -p`, pinning `_` and ` ` as well as `:` and `\`) |

## Evidence

- New test in `project.test.ts` with all four measured cases; the Windows case fails on the old rule with the exact production value.
- Typecheck (shared, rpc, server) green; project, tailer, adopt, discover and transcript suites green apart from three symlink tests that fail on Windows at baseline (symlink privilege).
- Verified live on Windows: with this line patched into the 0.8.1 bundle, the tailer errors stop and the board shows live progress.

Note: ten `scripts/seed-*.mjs` demo seeders carry a private copy of the old rule. They are development fixtures and are left as they are; they would want the same change if ever run on Windows.

Scope note: `cwdSlug` feeds only the `~/.claude/projects` joins, so this is Claude-backend-only; verified with the Claude Code backend on Windows. Companion Windows fix (independent, both needed for a working Windows experience): #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bj6zyZAbgahx4JD7SYJmZz
