### PR TITLE
fix(adopt): a promoted terminal session launches in the dispatch permission mode, not Claude's default

### DIFF
--- a/packages/server/src/adopt.test.ts
+++ b/packages/server/src/adopt.test.ts
@@ -60,6 +60,7 @@ function harness(options: {
   adoptionRuntime?: AdoptionRecoveryRuntime
   preflightAuth?: (kind: string) => Promise<"authed" | "signed-out" | "unknown">
   preflightCodexBinary?: () => Promise<"present" | "missing" | "unknown">
+  settings?: Partial<ReturnType<typeof defaultSettings>>
 } = {}) {
   const dir = mkdtempSync(join(tmpdir(), "frizz-adopt-"))
   const storage = createStorage(join(dir, "ui.db"), "p")
@@ -102,7 +103,7 @@ function harness(options: {
         errorItems: [],
       }
     },
-    getSettings: () => ({ ...defaultSettings(), model: "sonnet", effort: "high" }),
+    getSettings: () => ({ ...defaultSettings(), model: "sonnet", effort: "high", ...options.settings }),
     // Adoption spawns through the broker daemon. The fake records the same facts the
     // assertions below rely on (which slug/session/cwd, and the composed prompt).
     claudeBroker: {
@@ -608,6 +609,32 @@ test("adoptSession: a codex terminal pins the SAME id on agent_session_id, where
   assert.equal(row?.backend, "codex")
   // Codex writes no title record, so there is no name to inherit — the short id stands.
   assert.equal(row?.title, `Session ${ROLLOUT.slice(0, 8)}`)
+})
+
+// The follow-up that triggers a promotion resumes the session with `row.permission_mode`. A row
+// stamped with NOTHING fell through to the bridge's `"default"` — Claude's prompt-on-everything mode,
+// which the worker's perm-policy hook defers on every call — so a terminal session driven from the
+// board turned every Edit into a card (observed 2026-09-03). The promoted row therefore carries the
+// same Settings-driven launch mode a dispatched worker gets.
+test("adoptSession: the promoted row carries the dispatch launch mode, never an empty one", async () => {
+  const CLAUDE_ID = "6543d3fb-e38e-461a-b10a-9c78261b67b2"
+  const ROLLOUT = "01a01b81-bbf3-7841-b704-a7c4b95b7bd7"
+
+  // Shipped default: bypass for claude, danger-full-access for codex.
+  const shipped = harness()
+  await shipped.dispatcher.adoptSession({ sessionId: CLAUDE_ID, backend: "claude", title: "Terminal" })
+  await shipped.dispatcher.adoptSession({ sessionId: ROLLOUT, backend: "codex" })
+  assert.equal(shipped.storage.getSession(CLAUDE_ID)?.permission_mode, "bypassPermissions")
+  assert.equal(shipped.storage.getSession(ROLLOUT)?.permission_mode, "bypassPermissions")
+
+  // The one Settings deviation frizz honours for claude — and a restrictive value left by an older
+  // build still coerces to the floor rather than to Claude's `default`.
+  const auto = harness({ settings: { permissionMode: "auto" } })
+  await auto.dispatcher.adoptSession({ sessionId: CLAUDE_ID, backend: "claude", title: "Terminal" })
+  assert.equal(auto.storage.getSession(CLAUDE_ID)?.permission_mode, "auto")
+  const restrictive = harness({ settings: { permissionMode: "default" } })
+  await restrictive.dispatcher.adoptSession({ sessionId: CLAUDE_ID, backend: "claude", title: "Terminal" })
+  assert.equal(restrictive.storage.getSession(CLAUDE_ID)?.permission_mode, "auto")
 })
 
 test("adoptSession: a session frizz already owns cannot be promoted again, through EITHER id column", async () => {

--- a/packages/server/src/context.claude-wake.test.ts
+++ b/packages/server/src/context.claude-wake.test.ts
@@ -26,11 +26,14 @@ const row = {
   effort: "high",
   permission_mode: "bypassPermissions",
 }
+// The operator's Settings ask for `auto` here, so `auto` is the dispatch floor in these tests — chosen
+// to differ from the row's own persisted mode, so a wake that took the wrong one is caught.
+const settings = { permissionMode: "auto" as const }
 
 test("a scheduled wake carries everything a COLD RESUME needs to rebuild the worker", async () => {
   const b = bridge()
   await deliverClaudeBrokerWake({
-    bridge: b, slug: "rested-thread", cwd: process.cwd(), row,
+    bridge: b, slug: "rested-thread", cwd: process.cwd(), row, settings,
     deliveryMessage: "your timer fired",
   })
   assert.equal(b.calls.length, 1)
@@ -52,7 +55,7 @@ test("a failing bridge REJECTS the returned promise so the scheduler can retry",
   await assert.rejects(
     deliverClaudeBrokerWake({
       bridge: { followUp: async () => { throw new Error("the session broker is unavailable") } },
-      slug: "rested-thread", cwd: process.cwd(), row, deliveryMessage: "your timer fired",
+      slug: "rested-thread", cwd: process.cwd(), row, settings, deliveryMessage: "your timer fired",
     }),
     /session broker is unavailable/,
   )
@@ -64,8 +67,30 @@ test("a failing bridge REJECTS the returned promise so the scheduler can retry",
 // kill, which is why the sweep needs no coordination with the scheduler at all.
 test("freshProcess rides through untouched, and defaults to absent", async () => {
   const b = bridge()
-  await deliverClaudeBrokerWake({ bridge: b, slug: "s", cwd: process.cwd(), row, deliveryMessage: "m" })
+  await deliverClaudeBrokerWake({ bridge: b, slug: "s", cwd: process.cwd(), row, settings, deliveryMessage: "m" })
   assert.equal(b.calls[0].freshProcess, undefined)
-  await deliverClaudeBrokerWake({ bridge: b, slug: "s", cwd: process.cwd(), row, deliveryMessage: "m", freshProcess: true })
+  await deliverClaudeBrokerWake({ bridge: b, slug: "s", cwd: process.cwd(), row, settings, deliveryMessage: "m", freshProcess: true })
   assert.equal(b.calls[1].freshProcess, true)
+})
+
+// A row promoted from the External band by a build that stamped NO permission mode used to hand the
+// bridge `undefined`, which a cold resume turns into Claude's `default` — the prompt-on-everything mode
+// the worker's perm-policy hook defers call by call, so every Edit parked on a card (observed
+// 2026-09-03). The follow-up RPC substitutes the dispatch floor for such a row, and a scheduled wake —
+// a timer, a goal, a PR watch, a limit auto-resume — must do the same, or the legacy row converges only
+// when a human happens to type at it.
+test("a scheduled wake of a row with no recorded permission mode cold-resumes at the dispatch floor", async () => {
+  const b = bridge()
+  await deliverClaudeBrokerWake({
+    bridge: b, slug: "legacy", cwd: process.cwd(), row: { ...row, permission_mode: null }, settings,
+    deliveryMessage: "your timer fired",
+  })
+  assert.equal(b.calls[0].permissionMode, "auto", "the dispatch floor, not undefined → default")
+})
+
+// …and the row's own persisted mode always wins over that floor (the case above pins the difference).
+test("a scheduled wake carries a persisted permission mode over the dispatch floor", async () => {
+  const b = bridge()
+  await deliverClaudeBrokerWake({ bridge: b, slug: "s", cwd: process.cwd(), row, settings, deliveryMessage: "m" })
+  assert.equal(b.calls[0].permissionMode, "bypassPermissions")
 })

--- a/packages/server/src/context.ts
+++ b/packages/server/src/context.ts
@@ -18,7 +18,7 @@ import { readQuota } from "./quota.ts"
 import { refreshClaudeQuotaInBackground } from "./backend/claude-quota.ts"
 import { createBoard, type BoardManager } from "./board.ts"
 import { createTailer, defaultLogDir, type Tailer } from "./tailer.ts"
-import { createDispatcher, loadWorkerPrompt, scratchpadOrientation, frizzConfigBlock, claudeMcpConfig, resolveFrizzMcp, workerPluginDir, type Dispatcher, type FrizzMcpTarget } from "./dispatch.ts"
+import { createDispatcher, loadWorkerPrompt, scratchpadOrientation, frizzConfigBlock, claudeMcpConfig, resolveFrizzMcp, workerPluginDir, coldResumePermission, type Dispatcher, type FrizzMcpTarget } from "./dispatch.ts"
 import { createScheduler, type Scheduler, probePrReadable, type PrRef, type PrProbe } from "./scheduler.ts"
 import {
 resumeThread,
@@ -44,7 +44,6 @@ import {
   type ClaudeAgentBrokerBridge,
 } from "./backend/claude-agent-broker-bridge.ts"
 import { createClaudeRuntimeIngest, type ClaudeRuntimeIngest } from "./backend/claude-runtime-ingest.ts"
-import type { ClaudePermissionMode } from "./backend/claude-agent-sdk-protocol.ts"
 import { describeClaudeBrokerDiagnostic, droppedDeliveryId } from "./backend/claude-broker-diagnostics.ts"
 import { cancelDelivery } from "./delivery-ledger.ts"
 import {
@@ -409,11 +408,13 @@ export function deliverClaudeBrokerWake(deps: {
   slug: string
   cwd: string
   row: { session_id: string; model?: string | null; effort?: string | null; permission_mode?: string | null }
+  /** The operator's Settings, for the floor a row with NO persisted mode cold-resumes at (coldResumePermission). */
+  settings: Pick<Settings, "permissionMode">
   deliveryMessage: string
   /** Retire the live daemon first — see the bridge's followUp contract and needsFreshProcessForLimit. */
   freshProcess?: boolean
 }): Promise<void> {
-  const { bridge, slug, cwd, row, deliveryMessage, freshProcess } = deps
+  const { bridge, slug, cwd, row, settings, deliveryMessage, freshProcess } = deps
   const appendSystemPrompt = [
     loadWorkerPrompt("claude"),
     scratchpadOrientation(row.session_id, "claude"),
@@ -424,7 +425,7 @@ export function deliverClaudeBrokerWake(deps: {
     sessionId: row.session_id,
     cwd,
     text: deliveryMessage,
-    permissionMode: (row.permission_mode as ClaudePermissionMode | null) ?? undefined,
+    permissionMode: coldResumePermission(row, settings),
     appendSystemPrompt,
     model: row.model ?? undefined,
     effort: row.effort ?? undefined,
@@ -919,6 +920,7 @@ function createContextUnchecked(opts: ContextOptions, resources: PartialContextR
           slug,
           cwd: project.dir,
           row,
+          settings: getSettings(storage, home),
           deliveryMessage,
           // Recomputed here rather than carried on the delivery: the outbox stores a message, not a
           // runtime decision, and the tail is the live answer to "is this thread still behind a wall

--- a/packages/server/src/dispatch.ts
+++ b/packages/server/src/dispatch.ts
@@ -1069,6 +1069,13 @@ export function createDispatcher(deps: DispatchDeps): Dispatcher {
         state: "open",
         meta: null,
         seen_at: null,
+        // The SAME launch mode a dispatched worker gets. The follow-up that triggered this promotion
+        // resumes the session with `row.permission_mode`, and a row with none fell through to the
+        // bridge's `"default"` — Claude's prompt-on-everything mode, which the worker's own perm-policy
+        // hook then DEFERS on every call (`restrictive-mode`), so each Edit became a card. Observed
+        // 2026-09-03 on a terminal session driven from the board: every frizz-sent turn ran at
+        // `default` while the human's own TUI on the same transcript sat at `auto`.
+        permission_mode: workerDispatchPermission(backend, deps.getSettings()),
       })
       deps.storage.setBackend(slug, backend)
       if (backend === "codex") deps.storage.setAgentSession(slug, externalId)

--- a/packages/server/src/dispatch.ts
+++ b/packages/server/src/dispatch.ts
@@ -12,7 +12,7 @@ import {
   slugify,
   threadIdentityName,
   type Settings,
-  type PermissionMode,
+  PermissionMode,
   type ProviderAuth,
 } from "@frizz/shared"
 import { log as frizzLog } from "./logging.ts"
@@ -437,6 +437,19 @@ export const WORKER_DISPATCH_PERMISSION: Record<BackendKind, PermissionMode> = {
 export function workerDispatchPermission(kind: BackendKind, settings: Pick<Settings, "permissionMode">): PermissionMode {
   if (kind === "claude" && settings.permissionMode === "bypassPermissions") return "bypassPermissions"
   return WORKER_DISPATCH_PERMISSION[kind]
+}
+
+// The mode a Claude row COLD-RESUMES with. A persisted per-thread mode always wins; a row with none — a
+// terminal session promoted before adoptSession stamped one — takes the dispatch floor instead of
+// falling through to the bridge's `"default"`, Claude's prompt-on-everything mode, which the worker's
+// perm-policy hook defers call by call (observed 2026-09-03: every Edit became a card). Shared by every
+// path that can fork a process for an existing row — the follow-up RPC and the scheduled wakes (timer,
+// goal, PR watch, limit auto-resume) — so a legacy row converges the same way whichever one wakes it.
+// It shapes a FORK only: a daemon that outlived the upgrade is rebound as it is, and keeps its mode
+// until the operator's permission control or Restart worker replaces the process.
+export function coldResumePermission(row: { permission_mode?: string | null }, settings: Pick<Settings, "permissionMode">): PermissionMode {
+  const saved = PermissionMode.safeParse(row.permission_mode)
+  return saved.success ? saved.data : workerDispatchPermission("claude", settings)
 }
 
 // Canonical value that describes the permission policy the backend ACTUALLY receives. Claude's

--- a/packages/server/src/integration/limit-model-switch.integration.test.ts
+++ b/packages/server/src/integration/limit-model-switch.integration.test.ts
@@ -47,6 +47,7 @@ function schedulerOver(h: ReturnType<typeof createIntegrationHarness>, forks: Fo
         slug,
         cwd: h.project.dir,
         row,
+        settings: { permissionMode: "bypassPermissions" },
         deliveryMessage: message,
         freshProcess: needsFreshProcessForLimit(h.tailer.get(slug)?.limitFault, h.clockMs(), mayHaveLiveBackgroundWork(h.tailer.get(slug))),
       })

--- a/packages/server/src/router.test.ts
+++ b/packages/server/src/router.test.ts
@@ -1120,12 +1120,37 @@ function restartHarness(subAgents: { state: string }[] = []) {
   h.storage.upsertSession(row(slug))
   h.storage.setBackend(slug, "claude")
   h.storage.setClaudeRuntime(slug, "broker")
-  const calls: { text: string; freshProcess?: boolean }[] = []
+  const calls: { text: string; freshProcess?: boolean; permissionMode?: string }[] = []
   ;(h.ctx as { claudeBroker?: unknown }).claudeBroker = {
-    followUp: async (input: { text: string; freshProcess?: boolean }) => void calls.push(input),
+    followUp: async (input: { text: string; freshProcess?: boolean; permissionMode?: string }) => void calls.push(input),
   }
   return { h, slug, calls }
 }
+
+// A row promoted from the External band by a build that stamped NO permission mode used to hand the
+// bridge `undefined`, which a cold attach turns into Claude's `default` — the prompt-on-everything mode
+// the worker's perm-policy hook defers call by call, so every Edit parked on a card (observed
+// 2026-09-03). The follow-up substitutes the dispatch floor for such a row. It shapes the FORK only: a
+// daemon that outlived the upgrade is rebound as it is (the bridge ignores launch options for a held
+// daemon), and only a process replacement moves it. The stub here stands in for a bridge with no held
+// daemon, which is the case the substitute can reach.
+test("a follow-up on a row with no recorded permission mode cold-resumes at the dispatch floor", async () => {
+  const { h, slug, calls } = restartHarness()
+  assert.equal(h.storage.getSession(slug)?.permission_mode, null, "the legacy row carries no mode")
+  await h.router.followUp.handler({ input: { slug, sessionId: `sid-${slug}`, message: "carry on" } })
+  // This harness's Settings ask for `auto`, so `auto` is the dispatch floor here — and NOT undefined.
+  assert.equal(calls[0]?.permissionMode, "auto", "the dispatch floor, not undefined → default")
+  h.storage.close()
+})
+
+// …and a mode the operator persisted on the thread always wins over that floor.
+test("a follow-up on a row with a persisted permission mode carries that mode", async () => {
+  const { h, slug, calls } = restartHarness()
+  h.storage.setPermissionMode(slug, "bypassPermissions")
+  await h.router.followUp.handler({ input: { slug, sessionId: `sid-${slug}`, message: "carry on" } })
+  assert.equal(calls[0]?.permissionMode, "bypassPermissions")
+  h.storage.close()
+})
 
 test("Restart worker retires the live process, carrying the continuation into the fresh one", async () => {
   const { h, slug, calls } = restartHarness()

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -138,7 +138,7 @@ import { openLocalFile, readLocalMarkdown, resolveOpenableFile, readLocalTextFil
 import { openableFileRoots } from "./project.ts"
 import { ghInstalled, ghAuthed, ghRepo, gitGithubRemote, listItems, hydrateIssue, hydratePr, renderGithubPrompt, effectiveTemplate, DEFAULT_GITHUB_PROMPT } from "./github.ts"
 import { createGithubHovercardService } from "./github-hovercard.ts"
-import { slugify, resolveSlug, resolveLegacyThreadFile, loadWorkerPrompt, scratchpadOrientation, frizzConfigBlock, workerDispatchPermission } from "./dispatch.ts"
+import { slugify, resolveSlug, resolveLegacyThreadFile, loadWorkerPrompt, scratchpadOrientation, frizzConfigBlock, coldResumePermission } from "./dispatch.ts"
 import { readCodexModels } from "./backend/codex-models.ts"
 import { codexSandbox } from "./backend/codex.ts"
 import type { CodexSandboxMode } from "./backend/codex-app-server.ts"
@@ -1742,14 +1742,9 @@ export function createRouter(ctx: AppContext) {
             // Rides through to the SDK as this input's uuid, which the SDK echoes back on the record
             // that delivers it — the ledger then correlates by identity rather than by text.
             deliveryId: input.deliveryId,
-            // A row with NO recorded mode (a terminal session promoted before adoptSession stamped one)
-            // must not fall through to the bridge's `"default"` — Claude's prompt-on-everything mode,
-            // which the worker's perm-policy hook defers call by call. It cold-resumes at the same
-            // Settings-driven mode a dispatched worker launches with. This shapes a FORK only: a daemon
-            // that outlived the upgrade is rebound as it is, and keeps its mode until the operator's
-            // permission control (or Restart worker) replaces the process. An explicitly persisted
-            // per-thread mode always wins over the floor.
-            permissionMode: (row.permission_mode as ClaudePermissionMode | null) ?? workerDispatchPermission("claude", ctx.getSettings()),
+            // A persisted per-thread mode, or the dispatch floor for a row that has none — see
+            // coldResumePermission for why a legacy row must not fall through to the bridge's `"default"`.
+            permissionMode: coldResumePermission(row, ctx.getSettings()),
             appendSystemPrompt,
             model: row.model ?? undefined,
             effort: row.effort ?? undefined,

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -1744,8 +1744,11 @@ export function createRouter(ctx: AppContext) {
             deliveryId: input.deliveryId,
             // A row with NO recorded mode (a terminal session promoted before adoptSession stamped one)
             // must not fall through to the bridge's `"default"` — Claude's prompt-on-everything mode,
-            // which the worker's perm-policy hook defers call by call. It resumes at the same
-            // Settings-driven mode a dispatched worker launches with.
+            // which the worker's perm-policy hook defers call by call. It cold-resumes at the same
+            // Settings-driven mode a dispatched worker launches with. This shapes a FORK only: a daemon
+            // that outlived the upgrade is rebound as it is, and keeps its mode until the operator's
+            // permission control (or Restart worker) replaces the process. An explicitly persisted
+            // per-thread mode always wins over the floor.
             permissionMode: (row.permission_mode as ClaudePermissionMode | null) ?? workerDispatchPermission("claude", ctx.getSettings()),
             appendSystemPrompt,
             model: row.model ?? undefined,

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -138,7 +138,7 @@ import { openLocalFile, readLocalMarkdown, resolveOpenableFile, readLocalTextFil
 import { openableFileRoots } from "./project.ts"
 import { ghInstalled, ghAuthed, ghRepo, gitGithubRemote, listItems, hydrateIssue, hydratePr, renderGithubPrompt, effectiveTemplate, DEFAULT_GITHUB_PROMPT } from "./github.ts"
 import { createGithubHovercardService } from "./github-hovercard.ts"
-import { slugify, resolveSlug, resolveLegacyThreadFile, loadWorkerPrompt, scratchpadOrientation, frizzConfigBlock } from "./dispatch.ts"
+import { slugify, resolveSlug, resolveLegacyThreadFile, loadWorkerPrompt, scratchpadOrientation, frizzConfigBlock, workerDispatchPermission } from "./dispatch.ts"
 import { readCodexModels } from "./backend/codex-models.ts"
 import { codexSandbox } from "./backend/codex.ts"
 import type { CodexSandboxMode } from "./backend/codex-app-server.ts"
@@ -1742,7 +1742,11 @@ export function createRouter(ctx: AppContext) {
             // Rides through to the SDK as this input's uuid, which the SDK echoes back on the record
             // that delivers it — the ledger then correlates by identity rather than by text.
             deliveryId: input.deliveryId,
-            permissionMode: (row.permission_mode as ClaudePermissionMode | null) ?? undefined,
+            // A row with NO recorded mode (a terminal session promoted before adoptSession stamped one)
+            // must not fall through to the bridge's `"default"` — Claude's prompt-on-everything mode,
+            // which the worker's perm-policy hook defers call by call. It resumes at the same
+            // Settings-driven mode a dispatched worker launches with.
+            permissionMode: (row.permission_mode as ClaudePermissionMode | null) ?? workerDispatchPermission("claude", ctx.getSettings()),
             appendSystemPrompt,
             model: row.model ?? undefined,
             effort: row.effort ?? undefined,

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -138,7 +138,7 @@ import { openLocalFile, readLocalMarkdown, resolveOpenableFile, readLocalTextFil
 import { openableFileRoots } from "./project.ts"
 import { ghInstalled, ghAuthed, ghRepo, gitGithubRemote, listItems, hydrateIssue, hydratePr, renderGithubPrompt, effectiveTemplate, DEFAULT_GITHUB_PROMPT } from "./github.ts"
 import { createGithubHovercardService } from "./github-hovercard.ts"
-import { slugify, resolveSlug, resolveLegacyThreadFile, loadWorkerPrompt, scratchpadOrientation, frizzConfigBlock, workerDispatchPermission } from "./dispatch.ts"
+import { slugify, resolveSlug, resolveLegacyThreadFile, loadWorkerPrompt, scratchpadOrientation, frizzConfigBlock } from "./dispatch.ts"
 import { readCodexModels } from "./backend/codex-models.ts"
 import { codexSandbox } from "./backend/codex.ts"
 import type { CodexSandboxMode } from "./backend/codex-app-server.ts"
@@ -1742,11 +1742,7 @@ export function createRouter(ctx: AppContext) {
             // Rides through to the SDK as this input's uuid, which the SDK echoes back on the record
             // that delivers it — the ledger then correlates by identity rather than by text.
             deliveryId: input.deliveryId,
-            // A row with NO recorded mode (a terminal session promoted before adoptSession stamped one)
-            // must not fall through to the bridge's `"default"` — Claude's prompt-on-everything mode,
-            // which the worker's perm-policy hook defers call by call. It resumes at the same
-            // Settings-driven mode a dispatched worker launches with.
-            permissionMode: (row.permission_mode as ClaudePermissionMode | null) ?? workerDispatchPermission("claude", ctx.getSettings()),
+            permissionMode: (row.permission_mode as ClaudePermissionMode | null) ?? undefined,
             appendSystemPrompt,
             model: row.model ?? undefined,
             effort: row.effort ?? undefined,


### PR DESCRIPTION
## The bug

A session started in a terminal and then driven from the board (the External band) turns every Edit and Bash call into a permission card. Dispatched threads on the same machine never prompt.

`adoptSession` writes the promoted row with no `permission_mode`. The follow-up that triggered the promotion resumes the session with `row.permission_mode`, and an empty value falls through to the bridge's `"default"` - Claude's prompt-on-everything mode. The worker's own perm-policy hook (`restrictive-mode`) then defers every request in a mode other than `auto`, so each call parks on a card.

Observed 2026-09-03 (Windows Server 2022, frizz 0.9.0, claude 2.1.259): every frizz-sent turn in the transcript carried `permissionMode: "default"` while the human's own TUI on the same transcript sat at `auto`. The `perm-requests/<slug>.json` marker read `"permissionMode":"default","decision":"defer","rule":"restrictive-mode"`.

## The fix

- `adoptSession` stamps `workerDispatchPermission(backend, settings)` on the promoted row - the same Settings-driven launch mode a dispatched worker gets (bypass by default; `auto` when Settings says so; a restrictive stored value still coerces to the floor).
- `coldResumePermission` (dispatch.ts) is the one answer to "which mode does an existing row fork with": a persisted per-thread mode, else the dispatch floor. Both paths that can fork a process for an existing row call it - the follow-up RPC and the scheduled wakes (timer, goal, PR watch, limit auto-resume) via `deliverClaudeBrokerWake` - so a row promoted by an older build converges the same way whichever one wakes it. This shapes a fork only: a daemon that outlived the upgrade is rebound as it is and keeps its mode until the thread's permission control or Restart worker replaces the process (pullfrog review).

## Evidence

- New test in `adopt.test.ts`: the shipped default, the `auto` deviation and the restrictive coercion, for both backends.
- Two tests in `router.test.ts` and two in `context.claude-wake.test.ts`: a null-mode row cold-resumes at the dispatch floor, and a persisted mode is carried unchanged, on both the follow-up and the scheduled-wake path.
- Typecheck (shared, rpc, server) green; adopt, dispatch, router, wake and limit-resume suites green apart from the symlink tests that fail on Windows at baseline (symlink privilege) and the two CRLF golden-prompt tests.
- Verified live: with the adopt change built into the 0.9.0 bundle and the server restarted, a fresh terminal `claude -p` session promoted through `followUp` stored `permission_mode = bypassPermissions`, its frizz-sent turns carried `permissionMode: "bypassPermissions"`, and no permission marker was written.

Not Windows-specific: the same path is taken on every platform. Independent of #29 and #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)