### PR TITLE
fix(update): make the registry update work on Windows

### DIFF
--- a/packages/server/src/dev-supervisor.ts
+++ b/packages/server/src/dev-supervisor.ts
@@ -851,6 +851,12 @@ class Supervisor implements DevSupervisor {
           // parent-only flags are invalid or dangerous for a file-backed control-plane child.
           execArgv: [],
           stdio: ["inherit", "inherit", "inherit", "ipc"],
+          // A registry update leaves this supervisor with no console on Windows (its successor starts
+          // detached). A console program forked from a console-less parent gets a new, VISIBLE console
+          // window, and closing that window would stop the board. `windowsHide` keeps the window from
+          // appearing (measured 2026-09-07: hwnd 0 for the child and its children). No effect elsewhere.
+          // `fork` passes it to `spawn` at runtime; `ForkOptions` in @types/node 24 does not declare it.
+          ...({ windowsHide: true } as object),
         })
       } catch (error) {
         const message = `child spawn failed: ${error instanceof Error ? error.message : error}; watching for a corrective edit`

--- a/src/production-update.test.ts
+++ b/src/production-update.test.ts
@@ -1,19 +1,29 @@
 import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
 import { EventEmitter } from "node:events";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 import { parseCliArgs } from "./launcher.ts";
 import {
   PRODUCTION_PRINT_LAUNCHER_FLAG,
   PRODUCTION_REEXEC_FLAG,
+  canReexecInPlace,
   handoffToRegistrySuccessor,
+  npmRegistryReleaseAdapter,
   planRegistryUpdate,
   reexecIntoRegistrySuccessor,
+  resolveNpmInvocation,
   resolveRegistrySuccessor,
   successorArgs,
   type RegistryReleaseAdapter,
   type RegistrySuccessor,
 } from "./production-update.ts";
+
+const execFileP = promisify(execFile);
 
 const plan = { packageName: "frizz", currentVersion: "1.2.3", latestVersion: "1.3.0", packageSpec: "frizz@1.3.0" };
 // A file that exists, standing in for the successor's launcher bundle.
@@ -36,6 +46,69 @@ test("registry update selects an immutable newer package spec", async () => {
 
 test("registry lookup failure leaves the healthy process untouched", async () => {
   await assert.rejects(() => planRegistryUpdate("frizz", "1.2.3", { latestVersion: async () => { throw new Error("offline"); } }), /offline/);
+});
+
+test("npm runs as node + npm-cli.js — the bare `npm` name is only a `.cmd` shim on Windows", () => {
+  const node = join("/", "opt", "node", "bin", "node");
+  const cli = join("/", "opt", "node", "lib", "node_modules", "npm", "bin", "npm-cli.js");
+  const exists = (path: string) => path === cli;
+  const rows: Array<{ name: string; env: NodeJS.ProcessEnv; execPath: string; exists: (path: string) => boolean; expected: ReturnType<typeof resolveNpmInvocation> }> = [
+    { name: "npm_execpath names npm-cli.js", env: { npm_execpath: cli }, execPath: node, exists, expected: { command: node, prefixArgs: [cli] } },
+    { name: "an npx-cli.js hint resolves to the sibling npm-cli.js", env: { npm_execpath: join("/", "opt", "node", "lib", "node_modules", "npm", "bin", "npx-cli.js") }, execPath: node, exists, expected: { command: node, prefixArgs: [cli] } },
+    { name: "a pnpm hint has no npm-cli.js beside it", env: { npm_execpath: join("/", "opt", "pnpm", "bin", "pnpm.cjs") }, execPath: node, exists, expected: { command: node, prefixArgs: [cli] } },
+    { name: "no hint: the npm that ships with node (POSIX layout)", env: {}, execPath: node, exists, expected: { command: node, prefixArgs: [cli] } },
+    { name: "a stale hint that points nowhere is skipped", env: { npm_execpath: join("/", "gone", "npm-cli.js") }, execPath: node, exists, expected: { command: node, prefixArgs: [cli] } },
+  ];
+  const windowsNode = join("C:", "Program Files", "nodejs", "node.exe");
+  const windowsCli = join("C:", "Program Files", "nodejs", "node_modules", "npm", "bin", "npm-cli.js");
+  rows.push({ name: "no hint: the npm beside node.exe (Windows layout)", env: {}, execPath: windowsNode, exists: (path) => path === windowsCli, expected: { command: windowsNode, prefixArgs: [windowsCli] } });
+  for (const row of rows) assert.deepEqual(resolveNpmInvocation(row.env, row.execPath, row.exists, "linux"), row.expected, row.name);
+  // No script at all: POSIX keeps the bare command, Windows refuses (the bare name is a dead spawn there).
+  assert.deepEqual(resolveNpmInvocation({}, node, () => false, "linux"), { command: "npm", prefixArgs: [] });
+  assert.throws(() => resolveNpmInvocation({}, windowsNode, () => false, "win32"), /npm-cli\.js not found beside/);
+});
+
+test("the resolved npm invocation actually starts on this platform", async () => {
+  // Pins the spawn, not the registry: before this, Windows failed with `spawn npm ENOENT` because the
+  // bare name only reaches a `.cmd` shim there. `--version` is the cheapest thing npm answers offline.
+  const npm = resolveNpmInvocation();
+  const { stdout } = await execFileP(npm.command, [...npm.prefixArgs, "--version"], { encoding: "utf8" });
+  assert.match(stdout.trim(), /^\d+\.\d+\.\d+/u);
+});
+
+test("the in-place re-exec is only taken where execve works: never on Windows, even though the function exists there", () => {
+  const execve = () => {};
+  assert.equal(canReexecInPlace("linux", execve), true);
+  assert.equal(canReexecInPlace("darwin", execve), true);
+  // Node 24 on Windows defines process.execve and throws ERR_FEATURE_UNAVAILABLE_ON_PLATFORM when called.
+  assert.equal(canReexecInPlace("win32", execve), false);
+  assert.equal(canReexecInPlace("linux", null), false);
+});
+
+test("the real spawnDetached starts a detached node script that outlives the call", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "frizz-spawn-detached-"));
+  try {
+    const marker = join(dir, "started");
+    const entry = join(dir, "entry.cjs");
+    writeFileSync(entry, `require("node:fs").writeFileSync(process.argv[process.argv.length - 1], process.argv.slice(2).join(" "));`);
+    // cwd is the system temp dir, not `dir`: Windows refuses to remove a directory that is still a
+    // live process's working directory, and the child may outlive the assertion by a few ms.
+    const child = npmRegistryReleaseAdapter.spawnDetached({ entry, args: ["--port", "1", marker], cwd: tmpdir(), env: process.env });
+    child.unref();
+    // Poll until the marker holds the full text: a read can land between the child's create and its
+    // write, so a short or missing file is "not yet", and only the deadline is a failure.
+    const expected = `--port 1 ${marker}`;
+    const deadline = Date.now() + 10_000;
+    let seen = "";
+    while (Date.now() < deadline) {
+      try { seen = readFileSync(marker, "utf8"); } catch (error) { if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error; }
+      if (seen === expected) return;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    assert.equal(seen, expected, "the spawned entry never wrote its marker");
+  } finally {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+  }
 });
 
 // The 2026-09-10 failure, pinned at the seam that produced it: the successor was started with the

--- a/src/production-update.ts
+++ b/src/production-update.ts
@@ -1,9 +1,63 @@
 import { execFile, spawn } from "node:child_process";
 import type { ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
-import { isAbsolute } from "node:path";
+import { dirname, isAbsolute, join } from "node:path";
 
 export const PRODUCTION_REEXEC_FLAG = "--_frizz-production-reexec";
+
+export interface NpmInvocation {
+  command: string;
+  /** Arguments that go BEFORE the npm subcommand (the npm-cli.js script when node runs npm directly). */
+  prefixArgs: string[];
+}
+
+/**
+ * How to start npm from this process. `execFile("npm", …)` is not enough on Windows. There npm is only
+ * a `npm.cmd` shim. A shell-less spawn cannot find the shim (`spawn npm ENOENT`), and Node refuses to
+ * run a `.cmd` file without a shell. The reliable form is the one every shim ends in: this node binary
+ * running `npm-cli.js`. Three places can hold that script, in this order:
+ *
+ *   1. beside `npm_execpath`, which npm sets for a bin it runs itself (`npx frizz`, `npm exec`);
+ *   2. beside node.exe (the Windows installer layout);
+ *   3. under `../lib/node_modules` (the POSIX installer layout).
+ *
+ * A global bin started from a shell has no `npm_execpath`, so it gets the npm that ships with node.
+ * On POSIX the bare `npm` command is the fallback, which is the behaviour before this helper existed.
+ * On Windows there is no working fallback: the bare name only reaches the shim, and a swallowed spawn
+ * error would end the board with a success message. So Windows throws instead.
+ */
+export function resolveNpmInvocation(
+  env: NodeJS.ProcessEnv = process.env,
+  execPath: string = process.execPath,
+  exists: (path: string) => boolean = existsSync,
+  platform: NodeJS.Platform = process.platform
+): NpmInvocation {
+  const nodeDir = dirname(execPath);
+  const candidates = [
+    // pnpm, yarn and bun set `npm_execpath` too, to their own entry file. Their directories hold no
+    // `npm-cli.js`, so the existence check below skips them.
+    env.npm_execpath ? join(dirname(env.npm_execpath), "npm-cli.js") : undefined,
+    join(nodeDir, "node_modules", "npm", "bin", "npm-cli.js"),
+    join(nodeDir, "..", "lib", "node_modules", "npm", "bin", "npm-cli.js"),
+  ].filter((candidate): candidate is string => candidate !== undefined);
+  const script = candidates.find((candidate) => exists(candidate));
+  if (script) return { command: execPath, prefixArgs: [script] };
+  if (platform === "win32") {
+    throw new Error(`npm-cli.js not found beside ${execPath} (searched: ${candidates.join(", ")})`);
+  }
+  return { command: "npm", prefixArgs: [] };
+}
+
+/**
+ * Whether this process can replace itself with the successor. `process.execve` EXISTS on every
+ * platform from Node 23.11, but on Windows it only throws ERR_FEATURE_UNAVAILABLE_ON_PLATFORM
+ * (measured on Node 24.15, Windows Server 2022). A `typeof` check therefore passes there, and the
+ * update would dispose the pane host and the tunnel and then throw, after the board was drained.
+ * The platform is the only thing that can be checked without making the call.
+ */
+export function canReexecInPlace(platform: NodeJS.Platform = process.platform, execve: unknown = process.execve): boolean {
+  return platform !== "win32" && typeof execve === "function";
+}
 /**
  * Print the absolute path of the launcher bundle that is running and exit 0. Internal: this is how
  * an OLDER launcher finds the entry of the release it resolved through npm, so it can execve into it
@@ -148,9 +202,9 @@ export function reexecIntoRegistrySuccessor(
 }
 
 /**
- * Start the successor detached — the fallback for a runtime without `process.execve` (Windows).
- * This terminal is not handed to it: the launcher ends, and the board serves from a pid this
- * window can no longer signal. The caller has to say so.
+ * Start the successor detached — the fallback for a runtime where `process.execve` does not work
+ * (Windows, see `canReexecInPlace`). This terminal is not handed to it: the launcher ends, and the
+ * board serves from a pid this window can no longer signal. The caller has to say so.
  */
 export function handoffToRegistrySuccessor(
   successor: RegistrySuccessor,
@@ -174,7 +228,9 @@ export function handoffToRegistrySuccessor(
 export const npmRegistryReleaseAdapter: RegistryReleaseAdapter = {
   latestVersion(packageName) {
     return new Promise((resolveVersion, reject) => {
-      execFile("npm", ["view", `${packageName}@latest`, "version", "--json"], { encoding: "utf8" }, (error, stdout) => {
+      let npm: NpmInvocation;
+      try { npm = resolveNpmInvocation(); } catch (error) { return reject(error); }
+      execFile(npm.command, [...npm.prefixArgs, "view", `${packageName}@latest`, "version", "--json"], { encoding: "utf8", windowsHide: true }, (error, stdout) => {
         if (error) return reject(new Error(`could not check npm for ${packageName}: ${error.message}`));
         try {
           const parsed = JSON.parse(stdout) as unknown;
@@ -187,11 +243,14 @@ export const npmRegistryReleaseAdapter: RegistryReleaseAdapter = {
   },
   npmExec({ packageSpec, bin, args, cwd, env }) {
     return new Promise((settle) => {
+      let npm: NpmInvocation;
+      try { npm = resolveNpmInvocation(); } catch (error) { return settle({ code: null, signal: null, stdout: "", stderr: (error as Error).message }); }
       // The explicit package spec forces npm to resolve/install a new cache entry before running it.
-      const child = spawn("npm", ["exec", "--yes", `--package=${packageSpec}`, "--", bin, ...args], {
+      const child = spawn(npm.command, [...npm.prefixArgs, "exec", "--yes", `--package=${packageSpec}`, "--", bin, ...args], {
         cwd,
         env,
         stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
       });
       let stdout = "";
       let stderr = "";
@@ -202,6 +261,9 @@ export const npmRegistryReleaseAdapter: RegistryReleaseAdapter = {
     });
   },
   spawnDetached({ entry, args, cwd, env }) {
-    return spawn(process.execPath, [entry, ...args], { cwd, env, detached: true, stdio: "ignore" });
+    // `detached` gives the successor no console of its own, and `windowsHide` keeps the children it
+    // starts from opening one. Measured on Windows Server 2022: without `windowsHide` a forked child of
+    // a console-less parent gets a visible console window, and closing that window stops the board.
+    return spawn(process.execPath, [entry, ...args], { cwd, env, detached: true, stdio: "ignore", windowsHide: true });
   },
 };

--- a/src/production.ts
+++ b/src/production.ts
@@ -60,7 +60,7 @@ import {
 } from "@frizz/server/project-launch";
 import { createSupervisorShutdownHandler, startDevSupervisor } from "@frizz/server/dev-supervisor";
 import {
-  handoffToRegistrySuccessor, npmRegistryReleaseAdapter, planRegistryUpdate, PRODUCTION_PRINT_LAUNCHER_FLAG, PRODUCTION_REEXEC_FLAG,
+  canReexecInPlace, handoffToRegistrySuccessor, npmRegistryReleaseAdapter, planRegistryUpdate, PRODUCTION_PRINT_LAUNCHER_FLAG, PRODUCTION_REEXEC_FLAG,
   reexecIntoRegistrySuccessor, resolveRegistrySuccessor, type RegistrySuccessor,
 } from "./production-update.ts";
 import {
@@ -509,7 +509,7 @@ async function runSupervisor(port: number, token: string): Promise<never> {
       if (!successor) throw new Error("no update was prepared");
       const { plan } = successor;
       const successorEnv = { ...env, FRIZZ_REGISTRY_PACKAGE: plan.packageName, FRIZZ_REGISTRY_VERSION: plan.latestVersion };
-      if (typeof process.execve === "function") {
+      if (canReexecInPlace()) {
         // Same as frizz-dev's handoff: execve keeps this pid, this terminal and this stdio, so the
         // updated Frizz is the FOREGROUND process the operator started — ctrl-c still stops it, the
         // readout keeps narrating, closing the window still takes it down. The maintainer asked for
@@ -526,7 +526,7 @@ async function runSupervisor(port: number, token: string): Promise<never> {
         // keyed project resources, so neither process copies, deletes, nor recreates them.
         reexecIntoRegistrySuccessor(successor, { port, env: successorEnv });
       }
-      // No execve on this runtime (Windows): the successor starts detached with its stdio closed, so
+      // No working execve on this runtime (Windows): the successor starts detached with its stdio closed, so
       // this terminal is not handed to it — the process simply ends, the shell prompt returns, and
       // the board is still serving from a PID this window can no longer signal. Said plainly, that
       // is an update; unsaid, it is indistinguishable from Frizz dying.


### PR DESCRIPTION
## Problem

On Windows, clicking the Update button in the board fails with:

```
Update failed. Frizz kept running the previous version, and your threads are unaffected.
could not check npm for frizz: spawn npm ENOENT
```

Rebuilt on top of eaeedacc (install before drain, `node <entry>` successor), which fixed the argv problem this PR also carried. What remains is Windows-only, in one commit:

1. **npm spawn.** `execFile("npm", …)` runs with no shell. On Windows npm exists only as an `npm.cmd` shim and the `npm-cli.js` script, so the spawn fails. The same call feeds the 30-minute background probe, so the button always showed "Update". npm hands every bin it runs its own entry point in `npm_execpath`; the adapter now runs that script with the current `node`, or the `npm-cli.js` beside `node`, and POSIX keeps the bare `npm` as its fallback. Windows throws when no script exists, so the update reports a failure instead of ending the board with "Updated".

2. **`process.execve` on Windows.** It exists on Node 24 but throws `ERR_FEATURE_UNAVAILABLE_ON_PLATFORM` when called, so the `typeof` guard passed, the pane host and tunnel were disposed, and then the call threw. `canReexecInPlace()` also checks the platform; Windows takes the detached fallback.

3. **Console windows.** A console program started from a console-less parent gets a new, visible console window, and closing that window stopped the board. The detached successor, the npm calls, and the supervisor's forked server child pass `windowsHide`.

## Verification

- Unit tests pin the resolver's search order and spawn the resolved npm for real on the test platform; `canReexecInPlace` and the real detached spawn are covered.
- `node -e` probe on Windows Server 2022, Node 24.15: `process.execve` is a function and throws `ERR_FEATURE_UNAVAILABLE_ON_PLATFORM`.
- End to end on Windows Server 2022 with Node 24.15 and npm 11.13, on this exact commit: a build of this branch labelled 0.12.10 served a project on port 4998. `POST /_frizz/control/update-restart` installed the published 0.12.11 into its own npx execution cache, read the entry through `--_frizz-print-launcher`, and handed off. `/_frizz/control/status` then answered `"version":"0.12.11"` from the successor. The successor ran as `node <cache>\dist\frizz.js`, with no `cmd.exe` in its chain and no console window (`MainWindowHandle` 0).
- The successor in that run was the published 0.12.11, whose supervisor lacks the fork change, so its server child still showed a window. A build of this branch started the same detached way forks a server child with no window (measured 2026-09-07). From the release that carries this commit onward the whole tree is windowless.
- `tsc --noEmit -p .` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
