### PR TITLE
fix(server): serve the projects page on Windows

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -510,9 +510,14 @@ export function serveStatic(distDir: string, req: IncomingMessage, res: ServerRe
   // directory threw — every load of the projects page (`/`, `/?add=…`, `/?unknown=…`) answered
   // "not found" while `/project/<slug>` and every asset were fine (2026-09-09). `join` still
   // converts the separators for the filesystem.
-  const rel = posix.normalize((req.url ?? "/").split("?")[0]).replace(/^(\.\.[/\\])+/, "")
+  //
+  // Backslashes are folded into slashes FIRST. POSIX normalization would leave a `..\` segment
+  // alone, and the native `join` on Windows would then walk it, so `/..\web-dist-x\secret` escaped
+  // the root while still sharing its prefix (pullfrog on #34).
+  const rel = posix.normalize((req.url ?? "/").split("?")[0].replace(/\\/g, "/")).replace(/^(\.\.[/\\])+/, "")
   let file = join(distDir, rel === "/" ? "index.html" : rel)
-  if (!file.startsWith(distDir)) file = join(distDir, "index.html")
+  // Separator-aware: `web-dist-private` starts with `web-dist` and is still outside it.
+  if (!file.startsWith(distDir + sep)) file = join(distDir, "index.html")
   if (!existsSync(file)) file = join(distDir, "index.html") // SPA fallback
   try {
     const stats = statSync(file)

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2,7 +2,7 @@ export type { AppRouter } from "./router.ts"
 
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http"
 import { readFileSync, existsSync, statSync } from "node:fs"
-import { dirname, join, resolve, extname, normalize, sep } from "node:path"
+import { dirname, join, resolve, extname, posix, sep } from "node:path"
 import { DEFAULT_PORT, FRIZZ_ROUTE_PREFIX } from "@frizz/shared"
 import {
 ContextStartupError,
@@ -505,7 +505,12 @@ function staticIsFresh(req: IncomingMessage, etag: string, mtimeMs: number): boo
 // Serve a built asset from web/dist, falling back to index.html for SPA routes. Path is
 // normalized + confined to distDir so a request can't escape the root.
 export function serveStatic(distDir: string, req: IncomingMessage, res: ServerResponse) {
-  const rel = normalize((req.url ?? "/").split("?")[0]).replace(/^(\.\.[/\\])+/, "")
+  // A URL path is POSIX whatever the host is. The platform `normalize` turns "/" into "\" on
+  // Windows, so the root test below missed, the root resolved to distDir ITSELF, and reading a
+  // directory threw — every load of the projects page (`/`, `/?add=…`, `/?unknown=…`) answered
+  // "not found" while `/project/<slug>` and every asset were fine (2026-09-09). `join` still
+  // converts the separators for the filesystem.
+  const rel = posix.normalize((req.url ?? "/").split("?")[0]).replace(/^(\.\.[/\\])+/, "")
   let file = join(distDir, rel === "/" ? "index.html" : rel)
   if (!file.startsWith(distDir)) file = join(distDir, "index.html")
   if (!existsSync(file)) file = join(distDir, "index.html") // SPA fallback

--- a/packages/server/src/static-cache.test.ts
+++ b/packages/server/src/static-cache.test.ts
@@ -48,6 +48,18 @@ test("a hashed asset is immutable; the shell that names it is not", async () => 
   assert.ok(shell.headers.get("etag"))
 })
 
+// The root is the projects page, and the launcher sends an unknown folder there as `/?add=<dir>`.
+// On Windows the platform `normalize` turns "/" into "\", which missed the root test, resolved the
+// URL to the dist directory itself, and answered "not found" — while every other route worked, so
+// only the grid was broken and only there (2026-09-09).
+test("the root URL is the shell on every platform, with or without a query string", async () => {
+  for (const path of ["/", "/?add=D%3A%5Cscratch", "/?unknown=gone"]) {
+    const res = await fetch(`${origin}${path}`)
+    assert.equal(res.status, 200, path)
+    assert.match(await res.text(), /index-AAAA\.js/, path)
+  }
+})
+
 test("a request for a hashed asset that does not exist gets the SPA shell's policy, not the asset's", async () => {
   // The fallback resolves to index.html, so the policy has to follow the RESOLVED file. Deciding it
   // from the URL would pin the app shell forever under an /assets/ URL.

--- a/packages/server/src/static-cache.test.ts
+++ b/packages/server/src/static-cache.test.ts
@@ -3,7 +3,7 @@ import { createServer } from "node:http"
 import { connect } from "node:net"
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { basename, join } from "node:path"
 import { gunzipSync } from "node:zlib"
 import { after, before, test } from "node:test"
 import { serveStatic } from "./index.ts"
@@ -124,4 +124,40 @@ test("text is compressed when the client asks, and left alone when it does not",
   })
   assert.match(gzipped.headers, /content-encoding: gzip/i)
   assert.match(gunzipSync(gzipped.body).toString("utf8"), /globalThis\.build = "one"/)
+})
+
+// A backslash must not be a way OUT of the root. On Windows the native `join` reads `\` as a
+// separator, so a `..\` segment that POSIX normalization left alone walks up — and a sibling that
+// shares the root's name prefix passed a bare `startsWith(distDir)` (pullfrog on #34). The request
+// goes over a raw socket because fetch turns `\` into `/` before sending.
+test("a backslash traversal to a prefix-sharing sibling gets the shell, never the sibling's file", async () => {
+  const sibling = `${dist}-private`
+  mkdirSync(sibling)
+  writeFileSync(join(sibling, "secret.txt"), "SECRET")
+  const name = basename(sibling)
+  const rawGet = (path: string) =>
+    new Promise<{ status: number; body: string }>((resolve, reject) => {
+      const port = Number(new URL(origin).port)
+      const socket = connect(port, "127.0.0.1", () => {
+        socket.write(`GET ${path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n`)
+      })
+      const chunks: Buffer[] = []
+      socket.on("data", (chunk) => chunks.push(chunk))
+      socket.on("error", reject)
+      socket.on("end", () => {
+        const raw = Buffer.concat(chunks).toString("utf8")
+        const status = Number(/^HTTP\/1\.1 (\d{3})/u.exec(raw)?.[1])
+        resolve({ status, body: raw.slice(raw.indexOf("\r\n\r\n") + 4) })
+      })
+    })
+  try {
+    for (const path of [`/..\\${name}\\secret.txt`, `/assets/..\\..\\${name}\\secret.txt`, `/../${name}/secret.txt`]) {
+      const res = await rawGet(path)
+      assert.equal(res.status, 200, path)
+      assert.doesNotMatch(res.body, /SECRET/u, path)
+      assert.match(res.body, /index-(AAAA|BBBB)\.js/u, path)
+    }
+  } finally {
+    rmSync(sibling, { recursive: true, force: true })
+  }
 })


### PR DESCRIPTION
## Symptom

On Windows, the projects page answers `404 not found`. Every URL that lands there is affected: `/`, `/?add=<dir>` (the launcher's "add this folder" request) and `/?unknown=<slug>` (the redirect for a project that does not exist). `/project/<slug>` and every asset are fine. So `frizz` in a repository works, and `frizz` in a plain folder shows a bare "not found" page instead of the add-folder dialog.

Present in every release up to 0.12.7.

## Cause

`serveStatic` in `packages/server/src/index.ts` normalizes the URL path with the platform `normalize`. On win32, `path.normalize("/")` returns `"\"`. The root test `rel === "/"` then misses, the URL resolves to the dist directory itself, `readFileSync` throws `EISDIR`, and the catch answers 404 "not found".

## Fix

A URL path is POSIX on every host, so normalize it with `posix.normalize`. `join` still converts the separators for the filesystem.

Second commit, after the pullfrog review: every backslash is folded into a slash before normalization, so a `..\` segment is resolved as a path segment on every host instead of being walked by the native `join` on Windows. The confinement check is `startsWith(distDir + sep)`, so a sibling whose name shares the root's prefix (`web-dist-private`) is outside the root.

## Verification

- `static-cache.test.ts`: 1 new test fetches the root with and without a query string; 1 new test sends `/..\<sibling>\secret.txt` over a raw socket (fetch rewrites `\` before sending) against a prefix-sharing sibling directory and asserts the shell is served, never the file. On Windows, the 2 existing root fetches in that file already failed before this change and pass now. 7 of 7 pass on Windows (run without `--test-force-exit`, which crashes libuv on Windows at exit).
- Booted the 0.12.7 package with the patched server bundle in `--sandbox` mode on Windows, with a `web-dist-private/secret.txt` sibling beside `web-dist`. With the first commit only, a raw `GET /..\web-dist-private\secret.txt` returned `SECRET` (the review's finding, reproduced). With both commits it returns the shell, as do `/assets/..\..\web-dist-private\secret.txt`, `/../web-dist-private/secret.txt` and `/..%5Cweb-dist-private%5Csecret.txt`. `/`, `/?add=D%3A%5C...` and `/?unknown=nope` answer 200 with the shell, and Chrome shows the "Add this folder as a project?" dialog prefilled with the folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
